### PR TITLE
Update SignatureValidator.sol

### DIFF
--- a/contracts/libs/SignatureValidator.sol
+++ b/contracts/libs/SignatureValidator.sol
@@ -28,7 +28,7 @@ library SignatureValidator {
 		} else if (mode == SignatureMode.TREZOR) {
 			hash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n\x20", hash));
 		} else if (mode == SignatureMode.ADEX) {
-			hash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n108By signing this message, you acknowledge signing an AdEx bid with the hash:\n"));
+			hash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n108By signing this message, you acknowledge signing an AdEx bid with the hash:\n", hash));
 		}
 
 		return ecrecover(hash, v, signature[1], signature[2]) == signer;


### PR DESCRIPTION
This code branch probably wasn't tested at https://github.com/AdExNetwork/adex-protocol-eth/blob/master/test/TestAdExCore.js#L32 (maybe only tests SignatureMode.GETH?)

I don't know if this change is correct since I could find the string "By signing this message, you acknowledge signing an AdEx bid with the hash:" in the rest of the codebase, but I imagine the message should contain the hash to sign as well.

I didn't write the missing branch test because that probably ought to use the real signing code that generates this message, or at least check that it matches functionally.