### PR TITLE
Registry + IdentityFactory has deployAndFund

### DIFF
--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -1,10 +1,10 @@
 pragma solidity ^0.5.6;
 pragma experimental ABIEncoderV2;
 
-import "../libs/SafeMath.sol";
-import "../libs/SafeERC20.sol";
-import "../libs/SignatureValidator.sol";
-import "../libs/ChannelLibrary.sol";
+import "./libs/SafeMath.sol";
+import "./libs/SafeERC20.sol";
+import "./libs/SignatureValidator.sol";
+import "./libs/ChannelLibrary.sol";
 
 contract ValidatorRegistry {
 	// The contract will probably just use a mapping, but this is a generic interface

--- a/contracts/IdentityFactory.sol
+++ b/contracts/IdentityFactory.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.6;
 
-import "../libs/SafeERC20.sol";
+import "./libs/SafeERC20.sol";
 
 contract IdentityFactory {
 	event Deployed(address addr, uint256 salt);
@@ -12,9 +12,7 @@ contract IdentityFactory {
 
 	function deploy(bytes memory code, uint256 salt) public {
 		address addr;
-		assembly {
-			addr := create2(0, add(code, 0x20), mload(code), salt)
-		}
+		assembly { addr := create2(0, add(code, 0x20), mload(code), salt) }
 		require(addr != address(0), "FAILED_DEPLOYING");
 		emit Deployed(addr, salt);
 	}
@@ -22,9 +20,7 @@ contract IdentityFactory {
 	function deployAndFund(bytes memory code, uint256 salt, address tokenAddr, uint256 tokenAmount) public {
 		require(msg.sender == relayer, "ONLY_RELAYER");
 		address addr;
-		assembly {
-			addr := create2(0, add(code, 0x20), mload(code), salt)
-		}
+		assembly { addr := create2(0, add(code, 0x20), mload(code), salt) }
 		require(addr != address(0), "FAILED_DEPLOYING");
 		SafeERC20.transfer(tokenAddr, addr, tokenAmount);
 		emit Deployed(addr, salt);

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.5.6;
+
+contract Registry {
+	mapping (address => bool) public whitelisted;
+
+	// The owner will be changed to a SC that bridges into a polkadot praachain,
+	// once the full AdEx Registry is running
+	address public owner;
+	constructor() public {
+		owner = msg.sender;
+	}
+
+	function changeOwner(address newOwner) public {
+		require(msg.sender == owner, "ONLY_OWNER");
+		owner = newOwner;
+	}
+
+	function setWhitelisted(address addr, bool isWhitelisted) public {
+		require(msg.sender == owner, "ONLY_OWNER");
+		whitelisted[addr] = isWhitelisted;
+	}
+}

--- a/contracts/Registry.sol
+++ b/contracts/Registry.sol
@@ -1,6 +1,9 @@
 pragma solidity ^0.5.6;
 
 contract Registry {
+	event LogWhitelisted(address addr, bool isWhitelisted);
+	event LogChangedOwner(address oldOwner, address newOwner);
+
 	mapping (address => bool) public whitelisted;
 
 	// The owner will be changed to a SC that bridges into a polkadot praachain,
@@ -12,11 +15,13 @@ contract Registry {
 
 	function changeOwner(address newOwner) public {
 		require(msg.sender == owner, "ONLY_OWNER");
+		emit LogChangedOwner(owner, newOwner);
 		owner = newOwner;
 	}
 
 	function setWhitelisted(address addr, bool isWhitelisted) public {
 		require(msg.sender == owner, "ONLY_OWNER");
 		whitelisted[addr] = isWhitelisted;
+		emit LogWhitelisted(addr, isWhitelisted);
 	}
 }

--- a/contracts/extra/IdentityFactory.sol
+++ b/contracts/extra/IdentityFactory.sol
@@ -1,18 +1,18 @@
 pragma solidity ^0.5.6;
 
 contract IdentityFactory {
-  event Deployed(address addr, uint256 salt);
+	event Deployed(address addr, uint256 salt);
 
-  function deploy(bytes memory code, uint256 salt) public {
-    address addr;
-    assembly {
-      addr := create2(0, add(code, 0x20), mload(code), salt)
-    }
-    require(
-      addr != address(0),
-      "FAILED_DEPLOYING"
-    );
+	function deploy(bytes memory code, uint256 salt) public {
+		address addr;
+		assembly {
+			addr := create2(0, add(code, 0x20), mload(code), salt)
+		}
+		require(
+			addr != address(0),
+			"FAILED_DEPLOYING"
+		);
 
-    emit Deployed(addr, salt);
-  }
+		emit Deployed(addr, salt);
+	}
 }

--- a/contracts/extra/IdentityFactory.sol
+++ b/contracts/extra/IdentityFactory.sol
@@ -1,18 +1,32 @@
 pragma solidity ^0.5.6;
 
+import "../libs/SafeERC20.sol";
+
 contract IdentityFactory {
 	event Deployed(address addr, uint256 salt);
+
+	address public relayer;
+	constructor(address relayerAddr) public {
+		relayer = relayerAddr;
+	}
 
 	function deploy(bytes memory code, uint256 salt) public {
 		address addr;
 		assembly {
 			addr := create2(0, add(code, 0x20), mload(code), salt)
 		}
-		require(
-			addr != address(0),
-			"FAILED_DEPLOYING"
-		);
+		require(addr != address(0), "FAILED_DEPLOYING");
+		emit Deployed(addr, salt);
+	}
 
+	function deployAndFund(bytes memory code, uint256 salt, address tokenAddr, uint256 tokenAmount) public {
+		require(msg.sender == relayer, "ONLY_RELAYER");
+		address addr;
+		assembly {
+			addr := create2(0, add(code, 0x20), mload(code), salt)
+		}
+		require(addr != address(0), "FAILED_DEPLOYING");
+		SafeERC20.transfer(tokenAddr, addr, tokenAmount);
 		emit Deployed(addr, salt);
 	}
 }

--- a/test/TestAdExCore.js
+++ b/test/TestAdExCore.js
@@ -112,7 +112,7 @@ contract('AdExCore', function(accounts) {
 		assert.equal(await core.withdrawnPerUser(channelId, accounts[0]), tokens/2, 'channel hsa right withdrawnPerUser')
 		// @TODO: test merkle tree with 1 element (no proof); merkle proof with 2 elements, and then with many
 
-		// @TODO completely exhaust channel, use getWithdrawn to ensure it's exhausted (or have a JS lib convenience method)
+		// @TODO completely exhaust channel, use .withdrawn to ensure it's exhausted
 		// Bench: creating these: (elem1, elem2, elem3, tree, proof, stateRoot, hashToSignHex, sig1), 1000 times, takes ~6000ms
 		// Bench: creating these: (elem1, elem2, elem3, tree, proof, stateRoot, hashtoSignHex), 1000 times, takes ~300ms
 		// Bench: creating these: (tree, proof, stateRoot, hashtoSignHex), 1000 times, takes ~300ms

--- a/test/TestAdExCore.js
+++ b/test/TestAdExCore.js
@@ -2,10 +2,11 @@ const AdExCore = artifacts.require('AdExCore')
 const MockToken = artifacts.require('./mocks/Token')
 const MockLibs = artifacts.require('./mocks/Libs')
 
+const { moveTime, sampleChannel, expectEVMError } = require('./')
 const promisify = require('util').promisify
 const ethSign = promisify(web3.eth.sign.bind(web3))
 
-const { Channel, ChannelState, MerkleTree, splitSig } = require('../js')
+const { ChannelState, Channel, MerkleTree, splitSig } = require('../js')
 const { providers, Contract } = require('ethers')
 const web3Provider = new providers.Web3Provider(web3.currentProvider)
 
@@ -38,7 +39,7 @@ contract('AdExCore', function(accounts) {
 
 	it('channelOpen', async function() {
 		const blockTime = (await web3.eth.getBlock('latest')).timestamp
-		const channel = sampleChannel(accounts[0], tokens, blockTime+50, 0)
+		const channel = sampleChannel(accounts, token.address, accounts[0], tokens, blockTime+50, 0)
 		const receipt = await (await core.channelOpen(channel.toSolidityTuple())).wait()
 		const ev = receipt.events.find(x => x.event === 'LogChannelOpen') 
 		assert.ok(ev, 'has LogChannelOpen event')
@@ -52,7 +53,7 @@ contract('AdExCore', function(accounts) {
 
 	it('channelWithdrawExpired', async function() {
 		const blockTime = (await web3.eth.getBlock('latest')).timestamp
-		const channel = sampleChannel(accounts[0], tokens, blockTime+50, 1)
+		const channel = sampleChannel(accounts, token.address, accounts[0], tokens, blockTime+50, 1)
 
 		await (await core.channelOpen(channel.toSolidityTuple())).wait()
 
@@ -79,7 +80,7 @@ contract('AdExCore', function(accounts) {
 		const proof = tree.proof(elem1)
 
 		const blockTime = (await web3.eth.getBlock('latest')).timestamp
-		const channel = sampleChannel(accounts[0], tokens, blockTime+50, 2)
+		const channel = sampleChannel(accounts, token.address, accounts[0], tokens, blockTime+50, 2)
 		await (await core.channelOpen(channel.toSolidityTuple())).wait()
 
 		const stateRoot = tree.getRoot()
@@ -122,35 +123,4 @@ contract('AdExCore', function(accounts) {
 		// @TODO should the byzantine cases of channelWithdraw be in a separate test? (validators trying to attack)
 		// @TODO can't withdraw more than the entire channel deposit, even if validators allow it
 	})
-
-	function sampleChannel(creator, amount, validUntil, nonce) {
-		const spec = new Buffer(32)
-		spec.writeUInt32BE(nonce)
-		return new Channel({
-			creator,
-			tokenAddr: token.address,
-			tokenAmount: amount,
-			validUntil,
-			validators: [accounts[0], accounts[1]],
-			spec,
-		})
-	}
-	async function expectEVMError(promise, errString) {
-		try {
-			await promise;
-			assert.isOk(false, 'should have failed with '+errString)
-		} catch(e) {
-			assert.isOk(e.message.match(new RegExp('VM Exception while processing transaction: revert '+errString)), 'wrong error: '+e.message)
-		}
-	}
-	function moveTime(web3, time) {
-		return new Promise(function(resolve, reject) {
-			web3.currentProvider.send({
-				jsonrpc: '2.0',
-				method: 'evm_increaseTime',
-				params: [time],
-				id: 0,
-			}, (err, res) => err ? reject(err) : resolve(res))
-		})
-	}
 })

--- a/test/TestIdentity.js
+++ b/test/TestIdentity.js
@@ -42,7 +42,7 @@ contract('Identity', function(accounts) {
 		await token.setBalanceTo(id.address, 10000)
 
 		// This IdentityFactory is used to test counterfactual deployment
-		const idFactoryWeb3 = await IdentityFactory.new()
+		const idFactoryWeb3 = await IdentityFactory.new(relayerAddr)
 		identityFactory = new Contract(idFactoryWeb3.address, IdentityFactory._json.abi, signer)
 	})
 

--- a/test/TestRegistry.js
+++ b/test/TestRegistry.js
@@ -24,8 +24,13 @@ contract('Registry', function(accounts) {
 		// shold be false to start with
 		assert.equal(await registry.whitelisted(validator), false)
 		// we can set it to true
-		await (await registry.setWhitelisted(validator, true)).wait()
+		const receipt = await (await registry.setWhitelisted(validator, true)).wait()
 		assert.equal(await registry.whitelisted(validator), true)
+		const whitelistedEv = receipt.events.find(x => x.event === 'LogWhitelisted')
+		assert.ok(whitelistedEv, 'has LogWhitelisted')
+		assert.equal(validator, whitelistedEv.args.addr, 'whitelisted address in event matches')
+		assert.equal(true, whitelistedEv.args.isWhitelisted, 'whitelisted flag in event matches')
+
 		// we can set it to false
 		await (await registry.setWhitelisted(validator, false)).wait()
 		assert.equal(await registry.whitelisted(validator), false)
@@ -36,8 +41,13 @@ contract('Registry', function(accounts) {
 		const registryUser = new Contract(registry.address, Registry._json.abi, web3Provider.getSigner(accounts[2]))
 		expectEVMError(registryUser.changeOwner(accounts[2]), 'ONLY_OWNER')
 
-		await (await registry.changeOwner(accounts[2])).wait()
+		const receipt = await (await registry.changeOwner(accounts[2])).wait()
 		assert.equal(await registry.owner(), accounts[2], 'owner has updated')
+		const ownerChangedEv = receipt.events.find(x => x.event === 'LogChangedOwner')
+		assert.ok(ownerChangedEv, 'has LogChangedOwner')
+		assert.equal(ownerAddr, ownerChangedEv.args.oldOwner, 'old owner address in event matches')
+		assert.equal(accounts[2], ownerChangedEv.args.newOwner, 'new owner address in event matches')
+
 		// since the owner has changed, the previous owner can no longer change owner
 		expectEVMError(registry.changeOwner(accounts[3]), 'ONLY_OWNER')
 	})

--- a/test/TestRegistry.js
+++ b/test/TestRegistry.js
@@ -1,0 +1,44 @@
+const Registry = artifacts.require('Registry')
+
+const { expectEVMError } = require('./')
+const { providers, Contract } = require('ethers')
+const web3Provider = new providers.Web3Provider(web3.currentProvider)
+
+contract('Registry', function(accounts) {
+	const ownerAddr = accounts[0]
+	let registry
+	let registryUser
+
+	before(async function() {
+		const registryWeb3 = await Registry.new()
+		registry = new Contract(registryWeb3.address, Registry._json.abi, web3Provider.getSigner(ownerAddr))
+		registryUser = new Contract(registry.address, Registry._json.abi, web3Provider.getSigner(accounts[2]))
+	})
+
+	it('whitelist', async function() {
+		const validator = accounts[1]
+
+		// Another user cannot invoke
+		expectEVMError(registryUser.setWhitelisted(validator, true), 'ONLY_OWNER');
+
+		// shold be false to start with
+		assert.equal(await registry.whitelisted(validator), false)
+		// we can set it to true
+		await (await registry.setWhitelisted(validator, true)).wait()
+		assert.equal(await registry.whitelisted(validator), true)
+		// we can set it to false
+		await (await registry.setWhitelisted(validator, false)).wait()
+		assert.equal(await registry.whitelisted(validator), false)
+	})
+	
+	it('changing ownership', async function() {
+		// Another user cannot invoke
+		const registryUser = new Contract(registry.address, Registry._json.abi, web3Provider.getSigner(accounts[2]))
+		expectEVMError(registryUser.changeOwner(accounts[2]), 'ONLY_OWNER')
+
+		await (await registry.changeOwner(accounts[2])).wait()
+		assert.equal(await registry.owner(), accounts[2], 'owner has updated')
+		// since the owner has changed, the previous owner can no longer change owner
+		expectEVMError(registry.changeOwner(accounts[3]), 'ONLY_OWNER')
+	})
+})

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,37 @@
+const { Channel } = require('../js')
+
+async function expectEVMError(promise, errString) {
+	try {
+		await promise;
+		assert.isOk(false, 'should have failed with '+errString)
+	} catch(e) {
+		const expectedString = errString ?
+			'VM Exception while processing transaction: revert '+errString
+			: 'VM Exception while processing transaction: revert'
+		assert.equal(e.message, expectedString, 'error message is incorrect')
+	}
+}
+
+function sampleChannel(accounts, tokenAddr, creator, amount, validUntil, nonce) {
+	const spec = new Buffer(32)
+	spec.writeUInt32BE(nonce)
+	return new Channel({
+		creator,
+		tokenAddr,
+		tokenAmount: amount,
+		validUntil,
+		validators: [accounts[0], accounts[1]],
+		spec,
+	})
+}
+function moveTime(web3, time) {
+	return new Promise(function(resolve, reject) {
+		web3.currentProvider.send({
+			jsonrpc: '2.0',
+			method: 'evm_increaseTime',
+			params: [time],
+			id: 0,
+		}, (err, res) => err ? reject(err) : resolve(res))
+	})
+}
+module.exports = { expectEVMError, sampleChannel, moveTime }


### PR DESCRIPTION
implement a simple but long-term viable Registry contract; once we create the full AdEx registry, we can change the owner of the registry contract from our msig to a bridge contract

this PR also adds tests for the registry and tests for `channelOpen` as a routine operation, which depend son the registry for checking if the validators are whitelisted

it also adds `deployAndFund` to the factory, which allows the relayer to deploy new contracts and fund them from the factory's funds; this will be used for grant winners
