### PR TITLE
Identity: executeBySender

### DIFF
--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -127,6 +127,23 @@ contract Identity {
 		}
 	}
 
+	function executeBySender(Transaction[] memory txns)
+		public
+	{
+		require(privileges[msg.sender] >= uint8(PrivilegeLevel.Transactions), 'INSUFFICIENT_PRIVILEGE_SENDER');
+		uint len = txns.length;
+		for (uint i=0; i<len; i++) {
+			Transaction memory txn = txns[i];
+			require(txn.nonce == nonce, 'WRONG_NONCE');
+
+			nonce = nonce.add(1);
+
+			executeCall(txn.to, txn.value, txn.data);
+		}
+		// The actual anti-bricking mechanism - do not allow the sender to drop his own priviledges
+		require(privileges[msg.sender] >= uint8(PrivilegeLevel.Transactions), 'PRIVILEGE_NOT_DOWNGRADED');
+	}
+
 	function executeRoutines(RoutineAuthorization memory auth, bytes32[3] memory signature, RoutineOperation[] memory operations)
 		public
 	{

--- a/contracts/IdentityFactory.sol
+++ b/contracts/IdentityFactory.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.6;
 import "./libs/SafeERC20.sol";
 
 contract IdentityFactory {
-	event Deployed(address addr, uint256 salt);
+	event LogDeployed(address addr, uint256 salt);
 
 	address public relayer;
 	constructor(address relayerAddr) public {
@@ -14,7 +14,7 @@ contract IdentityFactory {
 		address addr;
 		assembly { addr := create2(0, add(code, 0x20), mload(code), salt) }
 		require(addr != address(0), "FAILED_DEPLOYING");
-		emit Deployed(addr, salt);
+		emit LogDeployed(addr, salt);
 	}
 
 	function deployAndFund(bytes memory code, uint256 salt, address tokenAddr, uint256 tokenAmount) public {
@@ -23,6 +23,6 @@ contract IdentityFactory {
 		assembly { addr := create2(0, add(code, 0x20), mload(code), salt) }
 		require(addr != address(0), "FAILED_DEPLOYING");
 		SafeERC20.transfer(tokenAddr, addr, tokenAmount);
-		emit Deployed(addr, salt);
+		emit LogDeployed(addr, salt);
 	}
 }

--- a/test/TestIdentity.js
+++ b/test/TestIdentity.js
@@ -232,6 +232,19 @@ contract('Identity', function(accounts) {
 		const receipt = await (await idWithSender.executeBySender([relayerTx.toSolidityTuple()])).wait()
 		assert.equal(receipt.events.length, 1, 'right number of events emitted')
 		assert.equal((await id.nonce()).toNumber(), initialNonce+1, 'nonce has increased with 1')
+
+		const invalidNonceTx = new Transaction({
+			...relayerTx,
+			nonce: relayerTx.nonce-1
+		})
+		await expectEVMError(idWithSender.executeBySender([invalidNonceTx.toSolidityTuple()]), 'WRONG_NONCE')
+
+		const invalidPrivTx = new Transaction({
+			...relayerTx,
+			nonce: (await id.nonce()).toNumber(),
+			data: idInterface.functions.setAddrPrivilege.encode([userAcc, 1]),
+		})
+		await expectEVMError(idWithSender.executeBySender([invalidPrivTx.toSolidityTuple()]), 'PRIVILEGE_NOT_DOWNGRADED')
 	})
 
 	it('relay routine operations', async function() {

--- a/test/TestIdentity.js
+++ b/test/TestIdentity.js
@@ -225,7 +225,7 @@ contract('Identity', function(accounts) {
 			to: id.address,
 			data: idInterface.functions.setAddrPrivilege.encode([userAcc, 4]),
 		})
-		
+
 		await expectEVMError(id.executeBySender([relayerTx.toSolidityTuple()]), 'INSUFFICIENT_PRIVILEGE_SENDER')
 
 		const idWithSender = new Contract(id.address, Identity._json.abi, web3Provider.getSigner(userAcc))

--- a/test/TestIdentity.js
+++ b/test/TestIdentity.js
@@ -90,7 +90,8 @@ contract('Identity', function(accounts) {
 		const deployReceipt = await (await deploy()).wait()
 
 		// The counterfactually generated expectedAddr matches
-		const deployEv = deployReceipt.events.find(x => x.event === 'Deployed')
+		const deployEv = deployReceipt.events.find(x => x.event === 'LogDeployed')
+		assert.ok(deployEv, 'has deployedEv')
 		assert.equal(expectedAddr, deployEv.args.addr, 'counterfactual contract address matches')
 		
 		// privilege level is OK
@@ -140,7 +141,7 @@ contract('Identity', function(accounts) {
 
 		// Call successfully
 		const receipt = await (await deployAndFund()).wait()
-		const deployedEv = receipt.events.find(x => x.event === 'Deployed')
+		const deployedEv = receipt.events.find(x => x.event === 'LogDeployed')
 		assert.ok(deployedEv, 'has deployedEv')
 		assert.equal(await token.balanceOf(deployedEv.args.addr), fundAmnt, 'deployed contract has received the funding amount')
 	})
@@ -229,7 +230,7 @@ contract('Identity', function(accounts) {
 
 		const idWithSender = new Contract(id.address, Identity._json.abi, web3Provider.getSigner(userAcc))
 		const receipt = await (await idWithSender.executeBySender([relayerTx.toSolidityTuple()])).wait()
-		assert.equal(receipt.events.length, 3, 'right number of events emitted')
+		assert.equal(receipt.events.length, 1, 'right number of events emitted')
 		assert.equal((await id.nonce()).toNumber(), initialNonce+1, 'nonce has increased with 1')
 	})
 


### PR DESCRIPTION
This PR adds a `executeBySender` method to the Identity, which allows a sender who is privileged enough (`>=PrivilegeLevel.Transactions`) to execute transactions themselves through the contract, without signing messages

this method does not pay out fees (the sender pays for the tx themselves)

another specific is that it doesn't need to check the `identityContract` field of the transaction; since there's no signature involved, there's no need for this replay protection