### PR TITLE
enhancement/tests: more comprehensive tests

### DIFF
--- a/contracts/libs/SafeMath.sol
+++ b/contracts/libs/SafeMath.sol
@@ -4,25 +4,25 @@ library SafeMath {
 
     function mul(uint a, uint b) internal pure returns (uint) {
         uint c = a * b;
-        assert(a == 0 || c / a == b);
+        require(a == 0 || c / a == b);
         return c;
     }
 
     function div(uint a, uint b) internal pure returns (uint) {
-        assert(b > 0);
+        require(b > 0);
         uint c = a / b;
-        assert(a == b * c + a % b);
+        require(a == b * c + a % b);
         return c;
     }
 
     function sub(uint a, uint b) internal pure returns (uint) {
-        assert(b <= a);
+        require(b <= a);
         return a - b;
     }
 
     function add(uint a, uint b) internal pure returns (uint) {
         uint c = a + b;
-        assert(c >= a);
+        require(c >= a);
         return c;
     }
 

--- a/test/TestAdExCore.js
+++ b/test/TestAdExCore.js
@@ -50,6 +50,8 @@ contract('AdExCore', function(accounts) {
 
 		assert.equal(ev.args.channelId, channel.hashHex(core.address), 'channel hash matches')
 		assert.equal(await core.states(channel.hash(core.address)), ChannelState.Active, 'channel state is correct')
+
+		await expectEVMError(core.channelOpen(channel.toSolidityTuple()), 'INVALID_STATE')
 	})
 
 	it('channelWithdrawExpired', async function() {
@@ -68,6 +70,9 @@ contract('AdExCore', function(accounts) {
 		assert.ok(receipt.events.find(x => x.event === 'LogChannelWithdrawExpired'), 'has LogChannelWihtdrawExpired event')
 		assert.equal(await core.states(channel.hash(core.address)), ChannelState.Expired, 'channel state is correct')
 		assert.equal(await token.balanceOf(userAcc), initialBal.toNumber() + tokens, 'funds are returned')
+
+		// cannot do it again
+		await expectEVMError(core.channelWithdrawExpired(channel.toSolidityTuple()), 'INVALID_STATE')
 	})
 
 	it('channelWithdraw', async function() {

--- a/test/TestAdExCore.js
+++ b/test/TestAdExCore.js
@@ -115,7 +115,12 @@ contract('AdExCore', function(accounts) {
 		assert.equal(await core.withdrawnPerUser(channelId, userAcc), userLeafAmnt, 'channel has right withdrawnPerUser')
 
 		// if we try with less, it won't work
-		// @TODO
+		const lessWithdrawArgs = await balanceTreeToWithdrawArgs(
+			channel,
+			{ [userAcc]: userLeafAmnt-1 },
+			userAcc, userLeafAmnt-1
+		)
+		await expectEVMError(channelWithdraw.apply(null, lessWithdrawArgs))
 
 		// we can do it again, but it's not gonna give us more tokens
 		const receipt2 = await (await validWithdraw()).wait()

--- a/test/TestAdExCore.js
+++ b/test/TestAdExCore.js
@@ -40,6 +40,10 @@ contract('AdExCore', function(accounts) {
 
 	it('channelOpen', async function() {
 		const blockTime = (await web3.eth.getBlock('latest')).timestamp
+
+		const channelWrongCreator = sampleChannel(accounts, token.address, accounts[1], tokens, blockTime+50, 0)
+		await expectEVMError(core.channelOpen(channelWrongCreator.toSolidityTuple()), 'INVALID_CREATOR')
+
 		const channel = sampleChannel(accounts, token.address, userAcc, tokens, blockTime+50, 0)
 		const receipt = await (await core.channelOpen(channel.toSolidityTuple())).wait()
 		const ev = receipt.events.find(x => x.event === 'LogChannelOpen') 

--- a/test/TestAdExCore.js
+++ b/test/TestAdExCore.js
@@ -151,6 +151,7 @@ contract('AdExCore', function(accounts) {
 		assert.ok(incWithdrawEvent, 'has LogChannelWithdraw event')
 		assert.equal(incWithdrawEvent.args.amount, 10, 'withdrawn amount is 10')
 		assert.equal(await core.withdrawn(channelId), incUserLeafAmnt, 'channel has the right withdrawn value')
+		assert.equal(await token.balanceOf(userAcc), incUserLeafAmnt, 'user has the right token amount')
 
 		await moveTime(web3, 100)
 		await expectEVMError(validWithdraw(), 'EXPIRED')

--- a/test/TestIdentity.js
+++ b/test/TestIdentity.js
@@ -243,6 +243,7 @@ contract('Identity', function(accounts) {
 				data: idInterface.functions.setAddrPrivilege.encode([userAcc, 4]),
 			})
 		)
+		const totalFee = txns.map(x => x.feeTokenAmount).reduce((a, b) => a+b, 0)
 
 		// Cannot use an invalid identityContract
 		const invalidTxns1 = [txns[0], { ...txns[1], identityContract: token.address }]
@@ -258,7 +259,7 @@ contract('Identity', function(accounts) {
 		assert.equal(receipt.events.filter(x => x.event === 'LogPrivilegeChanged').length, 2, 'LogPrivilegeChanged happened twice')
 		assert.equal(
 			await token.balanceOf(relayerAddr),
-			initialBal.toNumber() + txns.map(x => x.feeTokenAmount).reduce((a, b) => a+b, 0),
+			initialBal.toNumber() + totalFee,
 			'fee was paid out for all transactions'
 		)
 	})

--- a/test/TestRegistry.js
+++ b/test/TestRegistry.js
@@ -19,7 +19,7 @@ contract('Registry', function(accounts) {
 		const validator = accounts[1]
 
 		// Another user cannot invoke
-		expectEVMError(registryUser.setWhitelisted(validator, true), 'ONLY_OWNER');
+		await expectEVMError(registryUser.setWhitelisted(validator, true), 'ONLY_OWNER');
 
 		// shold be false to start with
 		assert.equal(await registry.whitelisted(validator), false)
@@ -34,11 +34,11 @@ contract('Registry', function(accounts) {
 	it('changing ownership', async function() {
 		// Another user cannot invoke
 		const registryUser = new Contract(registry.address, Registry._json.abi, web3Provider.getSigner(accounts[2]))
-		expectEVMError(registryUser.changeOwner(accounts[2]), 'ONLY_OWNER')
+		await expectEVMError(registryUser.changeOwner(accounts[2]), 'ONLY_OWNER')
 
 		await (await registry.changeOwner(accounts[2])).wait()
 		assert.equal(await registry.owner(), accounts[2], 'owner has updated')
 		// since the owner has changed, the previous owner can no longer change owner
-		expectEVMError(registry.changeOwner(accounts[3]), 'ONLY_OWNER')
+		await expectEVMError(registry.changeOwner(accounts[3]), 'ONLY_OWNER')
 	})
 })


### PR DESCRIPTION
Check out the issue for improving tests here:
https://github.com/AdExNetwork/adex-protocol-eth/issues/50

Other than that, the SafeMath library was updated to use `require` rather than `assert`. References here:

- https://medium.com/blockchannel/the-use-of-revert-assert-and-require-in-solidity-and-the-new-revert-opcode-in-the-evm-1a3a7990e06e
- https://github.com/aragon/aragonOS/blob/a68479107f564e6be98a6b877b78f635fca96dbe/contracts/lib/math/SafeMath.sol