### PR TITLE
RoutineAuthorizations reworked

### DIFF
--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -153,7 +153,7 @@ contract Identity {
 		require(auth.validUntil >= now, 'AUTHORIZATION_EXPIRED');
 		bytes32 hash = keccak256(abi.encode(auth));
 		address signer = SignatureValidator.recoverAddr(hash, signature);
-		require(privileges[signer] >= uint8(PrivilegeLevel.Routines), 'INSUFFICIENT_PRIVILEGE');
+		require(privileges[signer] >= uint8(PrivilegeLevel.Transactions), 'INSUFFICIENT_PRIVILEGE');
 		uint len = operations.length;
 		for (uint i=0; i<len; i++) {
 			RoutineOperation memory op = operations[i];

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -16,12 +16,13 @@ contract Identity {
 
 	// Storage
 	// WARNING: be careful when modifying this
-	// privileges must always be 0th thing in storage
+	// privileges and routineAuthorizations must always be 0th and 1th thing in storage
 	mapping (address => uint8) public privileges;
-	// The next allowed nonce
-	uint public nonce = 0;
 	// Routine authorizations
 	mapping (bytes32 => bool) public routineAuthorizations;
+
+	// The next allowed nonce
+	uint public nonce = 0;
 	// Routine operations are authorized at once for a period, fee is paid once
 	mapping (bytes32 => bool) public routinePaidFees;
 

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -20,7 +20,6 @@ contract Identity {
 	mapping (address => uint8) public privileges;
 	// Routine authorizations
 	mapping (bytes32 => bool) public routineAuthorizations;
-
 	// The next allowed nonce
 	uint public nonce = 0;
 	// Routine operations are authorized at once for a period, fee is paid once
@@ -178,7 +177,7 @@ contract Identity {
 				// Channel: open
 				(ChannelLibrary.Channel memory channel) = abi.decode(op.data, (ChannelLibrary.Channel));
 				// Ensure validity is sane
-				require(channel.validUntil <= now + CHANNEL_MAX_VALIDITY);
+				//require(channel.validUntil <= now + CHANNEL_MAX_VALIDITY, 'CHANNEL_EXCEEDED_MAX_VALID');
 				// Ensure all validators are whitelisted
 				uint validatorsLen = channel.validators.length;
 				for (uint j=0; j<validatorsLen; j++) {

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -28,6 +28,7 @@ contract Identity {
 	bytes4 private constant CHANNEL_WITHDRAW_SELECTOR = bytes4(keccak256('channelWithdraw((address,address,uint256,uint256,address[],bytes32),bytes32,bytes32[3][],bytes32[],uint256)'));
 	bytes4 private constant CHANNEL_WITHDRAW_EXPIRED_SELECTOR = bytes4(keccak256('channelWithdrawExpired((address,address,uint256,uint256,address[],bytes32))'));
 	bytes4 private constant CHANNEL_OPEN_SELECTOR = bytes4(keccak256('channelOpen((address,address,uint256,uint256,address[],bytes32))'));
+	uint256 private CHANNEL_MAX_VALIDITY = 90 days;
 
 	enum PrivilegeLevel {
 		None,
@@ -171,6 +172,8 @@ contract Identity {
 			} else if (op.mode == 3) {
 				// Channel: open
 				(ChannelLibrary.Channel memory channel) = abi.decode(op.data, (ChannelLibrary.Channel));
+				// Ensure validity is sane
+				require(channel.validUntil <= now + CHANNEL_MAX_VALIDITY);
 				// Ensure all validators are whitelisted
 				uint validatorsLen = channel.validators.length;
 				for (uint j=0; j<validatorsLen; j++) {

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -16,9 +16,8 @@ contract Identity {
 
 	// Storage
 	// WARNING: be careful when modifying this
-	// privileges and registryAddr must always be respectively the 0th and 1st thing in storage
+	// privileges must always be 0th thing in storage
 	mapping (address => uint8) public privileges;
-	address public registryAddr;
 	// The next allowed nonce
 	uint public nonce = 0;
 	// Routine operations are authorized at once for a period, fee is paid once
@@ -74,10 +73,9 @@ contract Identity {
 		bytes data;
 	}
 
-	constructor(address[] memory addrs, uint8[] memory privLevels, address regAddr)
+	constructor(address[] memory addrs, uint8[] memory privLevels)
 		public
 	{
-		registryAddr = regAddr;
 		uint len = privLevels.length;
 		for (uint i=0; i<len; i++) {
 			privileges[addrs[i]] = privLevels[i];

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -180,6 +180,10 @@ contract Identity {
 					);
 				}
 				executeCall(auth.outpace, 0, abi.encodePacked(CHANNEL_OPEN_SELECTOR, op.data));
+			} else if (op.mode == 4) {
+				// Approve OUTPACE
+				(address tokenAddr, uint amount) = abi.decode(op.data, (address, uint));
+				SafeERC20.approve(tokenAddr, auth.outpace, amount);
 			} else {
 				require(false, 'INVALID_MODE');
 			}

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -182,11 +182,9 @@ contract Identity {
 						"VALIDATOR_NOT_WHITELISTED"
 					);
 				}
+				SafeERC20.approve(channel.tokenAddr, auth.outpace, 0);
+				SafeERC20.approve(channel.tokenAddr, auth.outpace, channel.tokenAmount);
 				executeCall(auth.outpace, 0, abi.encodePacked(CHANNEL_OPEN_SELECTOR, op.data));
-			} else if (op.mode == 4) {
-				// Approve OUTPACE
-				(address tokenAddr, uint amount) = abi.decode(op.data, (address, uint));
-				SafeERC20.approve(tokenAddr, auth.outpace, amount);
 			} else {
 				require(false, 'INVALID_MODE');
 			}

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -29,7 +29,7 @@ contract Identity {
 	bytes4 private constant CHANNEL_WITHDRAW_SELECTOR = bytes4(keccak256('channelWithdraw((address,address,uint256,uint256,address[],bytes32),bytes32,bytes32[3][],bytes32[],uint256)'));
 	bytes4 private constant CHANNEL_WITHDRAW_EXPIRED_SELECTOR = bytes4(keccak256('channelWithdrawExpired((address,address,uint256,uint256,address[],bytes32))'));
 	bytes4 private constant CHANNEL_OPEN_SELECTOR = bytes4(keccak256('channelOpen((address,address,uint256,uint256,address[],bytes32))'));
-	uint256 private CHANNEL_MAX_VALIDITY = 90 days;
+	uint256 private constant CHANNEL_MAX_VALIDITY = 90 days;
 
 	enum PrivilegeLevel {
 		None,
@@ -177,7 +177,7 @@ contract Identity {
 				// Channel: open
 				(ChannelLibrary.Channel memory channel) = abi.decode(op.data, (ChannelLibrary.Channel));
 				// Ensure validity is sane
-				//require(channel.validUntil <= now + CHANNEL_MAX_VALIDITY, 'CHANNEL_EXCEEDED_MAX_VALID');
+				require(channel.validUntil <= (now + CHANNEL_MAX_VALIDITY), 'CHANNEL_EXCEEDED_MAX_VALID');
 				// Ensure all validators are whitelisted
 				uint validatorsLen = channel.validators.length;
 				for (uint j=0; j<validatorsLen; j++) {

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -64,6 +64,7 @@ contract Identity {
 		address identityContract;
 		address relayer;
 		address outpace;
+		address registry;
 		uint validUntil;
 		address feeTokenAddr;
 		uint feeTokenAmount;
@@ -178,7 +179,7 @@ contract Identity {
 				uint validatorsLen = channel.validators.length;
 				for (uint j=0; j<validatorsLen; j++) {
 					require(
-						ValidatorRegistry(registryAddr).whitelisted(channel.validators[j]),
+						ValidatorRegistry(auth.registry).whitelisted(channel.validators[j]),
 						"VALIDATOR_NOT_WHITELISTED"
 					);
 				}

--- a/contracts/libs/ChannelLibrary.sol
+++ b/contracts/libs/ChannelLibrary.sol
@@ -63,7 +63,7 @@ library ChannelLibrary {
 		if (channel.validUntil < currentTime) {
 			return false;
 		}
-		if (channel.validUntil > currentTime + MAX_VALIDITY) {
+		if (channel.validUntil > (currentTime + MAX_VALIDITY)) {
 			return false;
 		}
 

--- a/js/Identity.js
+++ b/js/Identity.js
@@ -92,8 +92,10 @@ RoutineAuthorization.prototype.toSolidityTuple = function() {
 	]
 }
 
-RoutineAuthorization.encodeWithdraw = function(tokenAddr, to, amount) {
-	return abi.rawEncode(['address', 'address', 'uint256'], [tokenAddr, to, amount])
+const RoutineOps = {
+	withdraw: function(tokenAddr, to, amount) {
+		return [2, abi.rawEncode(['address', 'address', 'uint256'], [tokenAddr, to, amount])]
+	},
 }
 
-module.exports = { Transaction, RoutineAuthorization }
+module.exports = { Transaction, RoutineAuthorization, RoutineOps }

--- a/js/Identity.js
+++ b/js/Identity.js
@@ -10,7 +10,7 @@ function Transaction(args) {
 	this.identityContract = ensure.Address(args.identityContract)
 	this.nonce = ensure.Uint256(args.nonce)
 	this.feeTokenAddr = ensure.Address(args.feeTokenAddr)
-	this.feeTokenAmount = ensure.Uint256(args.feeTokenAmount)
+	this.feeAmount = ensure.Uint256(args.feeAmount)
 	this.to = ensure.Address(args.to)
 	this.value = ensure.Uint256(args.value)
 	this.data = ensure.Bytes(args.data)
@@ -25,7 +25,7 @@ Transaction.prototype.hash = function() {
 			this.identityContract,
 			this.nonce,
 			this.feeTokenAddr,
-			this.feeTokenAmount,
+			this.feeAmount,
 			this.to,
 			this.value,
 			this.data
@@ -44,7 +44,7 @@ Transaction.prototype.toSolidityTuple = function() {
 		this.identityContract,
 		`0x${this.nonce.toString(16)}`,
 		this.feeTokenAddr,
-		`0x${this.feeTokenAmount.toString(16)}`,
+		`0x${this.feeAmount.toString(16)}`,
 		this.to,
 		`0x${this.value.toString(16)}`,
 		`0x${this.data.toString('hex')}`
@@ -57,7 +57,7 @@ function RoutineAuthorization(args) {
 	this.registry = ensure.Address(args.registry)
 	this.validUntil = ensure.Uint256(args.validUntil)
 	this.feeTokenAddr = ensure.Address(args.feeTokenAddr)
-	this.feeTokenAmount = ensure.Uint256(args.feeTokenAmount)
+	this.feeAmount = ensure.Uint256(args.feeAmount)
 	Object.freeze(this)
 	return this
 }
@@ -71,7 +71,7 @@ RoutineAuthorization.prototype.hash = function() {
 			this.registry,
 			this.validUntil,
 			this.feeTokenAddr,
-			this.feeTokenAmount
+			this.feeAmount
 		]
 	)
 	return Buffer.from(keccak256.arrayBuffer(buf))
@@ -89,7 +89,7 @@ RoutineAuthorization.prototype.toSolidityTuple = function() {
 		this.registry,
 		`0x${this.validUntil.toString(16)}`,
 		this.feeTokenAddr,
-		`0x${this.feeTokenAmount.toString(16)}`
+		`0x${this.feeAmount.toString(16)}`
 	]
 }
 

--- a/js/Identity.js
+++ b/js/Identity.js
@@ -52,7 +52,6 @@ Transaction.prototype.toSolidityTuple = function() {
 }
 
 function RoutineAuthorization(args) {
-	this.identityContract = ensure.Address(args.identityContract)
 	this.relayer = ensure.Address(args.relayer)
 	this.outpace = ensure.Address(args.outpace)
 	this.registry = ensure.Address(args.registry)
@@ -65,9 +64,8 @@ function RoutineAuthorization(args) {
 
 RoutineAuthorization.prototype.hash = function() {
 	const buf = abi.rawEncode(
-		['address', 'address', 'address', 'address', 'uint256', 'address', 'uint256'],
+		['address', 'address', 'address', 'uint256', 'address', 'uint256'],
 		[
-			this.identityContract,
 			this.relayer,
 			this.outpace,
 			this.registry,
@@ -86,7 +84,6 @@ RoutineAuthorization.prototype.hashHex = function() {
 RoutineAuthorization.prototype.toSolidityTuple = function() {
 	// etherjs doesn't seem to want BN.js instances; hex is the lowest common denominator for web3/ethers
 	return [
-		this.identityContract,
 		this.relayer,
 		this.outpace,
 		this.registry,

--- a/js/Identity.js
+++ b/js/Identity.js
@@ -109,7 +109,7 @@ const RoutineOps = {
 	},
 	withdraw(tokenAddr, to, amount) {
 		return [3, abi.rawEncode(['address', 'address', 'uint256'], [tokenAddr, to, amount])]
-	},
+	}
 }
 
 module.exports = { Transaction, RoutineAuthorization, RoutineOps }

--- a/js/Identity.js
+++ b/js/Identity.js
@@ -1,6 +1,10 @@
 const abi = require('ethereumjs-abi')
 const keccak256 = require('js-sha3').keccak256
+const { Interface } = require('ethers').utils
 const ensure = require('./ensureTypes')
+const coreABI = require('../abi/AdExCore')
+
+const coreInterface = new Interface(coreABI)
 
 function Transaction(args) {
 	this.identityContract = ensure.Address(args.identityContract)
@@ -93,9 +97,22 @@ RoutineAuthorization.prototype.toSolidityTuple = function() {
 }
 
 const RoutineOps = {
-	withdraw: function(tokenAddr, to, amount) {
+	withdraw(tokenAddr, to, amount) {
 		return [2, abi.rawEncode(['address', 'address', 'uint256'], [tokenAddr, to, amount])]
 	},
+	// @TODO is there a more elegant way to remove the SELECTOR than .slice(10)?
+	channelWithdraw(args) {
+		const data = `0x${coreInterface.functions.channelWithdraw.encode(args).slice(10)}`
+		return [0, data]
+	},
+	channelWithdrawExpired(args) {
+		const data = `0x${coreInterface.functions.channelWithdrawExpired.encode(args).slice(10)}`
+		return [1, data]
+	},
+	channelOpen(args) {
+		const data = `0x${coreInterface.functions.channelOpen.encode(args).slice(10)}`
+		return [3, data]
+	}
 }
 
 module.exports = { Transaction, RoutineAuthorization, RoutineOps }

--- a/js/Identity.js
+++ b/js/Identity.js
@@ -51,6 +51,7 @@ function RoutineAuthorization(args) {
 	this.identityContract = ensure.Address(args.identityContract)
 	this.relayer = ensure.Address(args.relayer)
 	this.outpace = ensure.Address(args.outpace)
+	this.registry = ensure.Address(args.registry)
 	this.validUntil = ensure.Uint256(args.validUntil)
 	this.feeTokenAddr = ensure.Address(args.feeTokenAddr)
 	this.feeTokenAmount = ensure.Uint256(args.feeTokenAmount)
@@ -60,11 +61,12 @@ function RoutineAuthorization(args) {
 
 RoutineAuthorization.prototype.hash = function() {
 	const buf = abi.rawEncode(
-		['address', 'address', 'address', 'uint256', 'address', 'uint256'],
+		['address', 'address', 'address', 'address', 'uint256', 'address', 'uint256'],
 		[
 			this.identityContract,
 			this.relayer,
 			this.outpace,
+			this.registry,
 			this.validUntil,
 			this.feeTokenAddr,
 			this.feeTokenAmount
@@ -83,6 +85,7 @@ RoutineAuthorization.prototype.toSolidityTuple = function() {
 		this.identityContract,
 		this.relayer,
 		this.outpace,
+		this.registry,
 		`0x${this.validUntil.toString(16)}`,
 		this.feeTokenAddr,
 		`0x${this.feeTokenAmount.toString(16)}`

--- a/js/Identity.js
+++ b/js/Identity.js
@@ -97,9 +97,6 @@ RoutineAuthorization.prototype.toSolidityTuple = function() {
 }
 
 const RoutineOps = {
-	withdraw(tokenAddr, to, amount) {
-		return [2, abi.rawEncode(['address', 'address', 'uint256'], [tokenAddr, to, amount])]
-	},
 	// @TODO is there a more elegant way to remove the SELECTOR than .slice(10)?
 	channelWithdraw(args) {
 		const data = `0x${coreInterface.functions.channelWithdraw.encode(args).slice(10)}`
@@ -111,8 +108,11 @@ const RoutineOps = {
 	},
 	channelOpen(args) {
 		const data = `0x${coreInterface.functions.channelOpen.encode(args).slice(10)}`
-		return [3, data]
-	}
+		return [2, data]
+	},
+	withdraw(tokenAddr, to, amount) {
+		return [3, abi.rawEncode(['address', 'address', 'uint256'], [tokenAddr, to, amount])]
+	},
 }
 
 module.exports = { Transaction, RoutineAuthorization, RoutineOps }

--- a/js/IdentityProxyDeploy.js
+++ b/js/IdentityProxyDeploy.js
@@ -6,7 +6,7 @@ const assert = require('assert')
 // opts:
 // * privSlot: the storage slots used by the proxiedAddr
 // * unsafeERC20: true OR safeERC20Artifact
-function getProxyDeployTx(proxiedAddr, feeTokenAddr, feeBeneficiery, feeAmnt, privLevels, opts) {
+function getProxyDeployTx(proxiedAddr, privLevels, opts) {
 	assert.ok(opts, 'opts not passed')
 	const { privSlot, routineAuthsSlot } = opts
 	assert.ok(typeof privSlot === 'number', 'privSlot is a number')
@@ -35,18 +35,19 @@ function getProxyDeployTx(proxiedAddr, feeTokenAddr, feeBeneficiery, feeAmnt, pr
 
 	let erc20Header = ''
 	let feeCode = ''
-	if (feeAmnt > 0) {
+	if (opts.fee) {
+		const fee = opts.fee
 		// This is fine if we're only accepting whitelisted tokens
-		if (opts.unsafeERC20) {
+		if (fee.unsafeERC20) {
 			erc20Header = `interface GeneralERC20 { function transfer(address to, uint256 value) external; }`
-			feeCode = `GeneralERC20(${feeTokenAddr}).transfer(${feeBeneficiery}, ${feeAmnt});`
+			feeCode = `GeneralERC20(${fee.tokenAddr}).transfer(${fee.recepient}, ${fee.amount});`
 		} else {
-			assert.ok(opts.safeERC20Artifact, 'opts: either unsafeERC20 or safeERC20Artifact required')
-			erc20Header = opts.safeERC20Artifact.source
+			assert.ok(fee.safeERC20Artifact, 'opts: either unsafeERC20 or safeERC20Artifact required')
+			erc20Header = fee.safeERC20Artifact.source
 				.split('\n')
 				.filter(x => !x.startsWith('pragma '))
 				.join('\n')
-			feeCode = `SafeERC20.transfer(${feeTokenAddr}, ${feeBeneficiery}, ${feeAmnt});`
+			feeCode = `SafeERC20.transfer(${fee.tokenAddr}, ${fee.recepient}, ${fee.amount});`
 		}
 	}
 

--- a/js/IdentityProxyDeploy.js
+++ b/js/IdentityProxyDeploy.js
@@ -13,7 +13,7 @@ function getMappingSstore(slotNumber, keyType, key, value) {
 // opts:
 // * privSlot: the storage slots used by the proxiedAddr
 // * unsafeERC20: true OR safeERC20Artifact
-function getProxyDeployTx(proxiedAddr, privLevels, opts) {
+function getProxyDeployBytecode(proxiedAddr, privLevels, opts) {
 	assert.ok(opts, 'opts not passed')
 	const { privSlot, routineAuthsSlot } = opts
 	assert.ok(typeof privSlot === 'number', 'privSlot is a number')
@@ -90,9 +90,15 @@ contract IdentityProxy {
 	}
 	const output = JSON.parse(solc.compile(JSON.stringify(input)))
 	assert.ifError(output.errors)
-	const byteCode = `0x${output.contracts['Proxy.sol'].IdentityProxy.evm.bytecode.object}`
-	return { data: byteCode }
+	return `0x${output.contracts['Proxy.sol'].IdentityProxy.evm.bytecode.object}`
 }
+
+/*
+function getProxyDeploy(proxiedAddr, privLevels, opts) {
+	const bytecode = getProxyDeployBytecode(proxiedAddr, privLevels, opts)
+	return { bytecode, address, salt }
+}
+*/
 
 function getStorageSlotsFromArtifact(IdentityArtifact) {
 	// Find storage locations of privileges
@@ -110,4 +116,4 @@ function getStorageSlotsFromArtifact(IdentityArtifact) {
 	return { privSlot, routineAuthsSlot }
 }
 
-module.exports = { getProxyDeployTx, getStorageSlotsFromArtifact }
+module.exports = { getProxyDeployBytecode, getStorageSlotsFromArtifact }

--- a/js/IdentityProxyDeploy.js
+++ b/js/IdentityProxyDeploy.js
@@ -6,14 +6,7 @@ const assert = require('assert')
 // opts:
 // * privSlot: the storage slots used by the proxiedAddr
 // * unsafeERC20: true OR safeERC20Artifact
-function getProxyDeployTx(
-	proxiedAddr,
-	feeTokenAddr,
-	feeBeneficiery,
-	feeAmnt,
-	privLevels,
-	opts
-) {
+function getProxyDeployTx(proxiedAddr, feeTokenAddr, feeBeneficiery, feeAmnt, privLevels, opts) {
 	assert.ok(opts, 'opts not passed')
 	const { privSlot } = opts
 	assert.ok(typeof privSlot === 'number', 'privSlot is a number')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adex-protocol-eth",
-  "version": "2.3.2",
+  "version": "3.0.0",
   "description": "AdEx protocol on Ethereum",
   "directories": {
     "test": "test"

--- a/test/TestIdentity.js
+++ b/test/TestIdentity.js
@@ -86,14 +86,10 @@ contract('Identity', function(accounts) {
 			feeTokenAddr: token.address,
 			feeTokenAmount: 0
 		})
-		const deployTx = getProxyDeployTx(
-			baseIdentityAddr,
-			[[userAcc, 3]],
-			{
-				routineAuthorizations: [defaultAuth.hash()],
-				...getStorageSlotsFromArtifact(Identity)
-			}
-		)
+		const deployTx = getProxyDeployTx(baseIdentityAddr, [[userAcc, 3]], {
+			routineAuthorizations: [defaultAuth.hash()],
+			...getStorageSlotsFromArtifact(Identity)
+		})
 		const receipt = await (await identityFactory.deploy(deployTx.data, 0, { gasLimit })).wait()
 		const deployedEv = receipt.events.find(x => x.event === 'LogDeployed')
 		id = new Contract(deployedEv.args.addr, Identity._json.abi, signer)
@@ -105,21 +101,17 @@ contract('Identity', function(accounts) {
 		const feeAmnt = 250
 
 		// Generating a proxy deploy transaction
-		const deployTx = getProxyDeployTx(
-			baseIdentityAddr,
-			[[userAcc, 3]],
-			{
-				fee: {
-					tokenAddr: token.address,
-					recepient: relayerAddr,
-					amount: feeAmnt,
-					// Using this option is fine if the token.address is a token that reverts on failures
-					unsafeERC20: true,
-					//safeERC20Artifact: artifacts.require('SafeERC20')
-				},
-				...getStorageSlotsFromArtifact(Identity)
-			}
-		)
+		const deployTx = getProxyDeployTx(baseIdentityAddr, [[userAcc, 3]], {
+			fee: {
+				tokenAddr: token.address,
+				recepient: relayerAddr,
+				amount: feeAmnt,
+				// Using this option is fine if the token.address is a token that reverts on failures
+				unsafeERC20: true
+				// safeERC20Artifact: artifacts.require('SafeERC20')
+			},
+			...getStorageSlotsFromArtifact(Identity)
+		})
 
 		const salt = `0x${Buffer.from(randomBytes(32)).toString('hex')}`
 		const expectedAddr = getAddress(

--- a/test/TestIdentity.js
+++ b/test/TestIdentity.js
@@ -343,6 +343,7 @@ contract('Identity', function(accounts) {
 			identityContract: id.address,
 			relayer: relayerAddr,
 			outpace: coreAddr,
+			registry: registryAddr,
 			validUntil: blockTime + DAY_SECONDS,
 			feeTokenAddr: token.address,
 			feeTokenAmount: fee
@@ -454,6 +455,7 @@ contract('Identity', function(accounts) {
 			identityContract: id.address,
 			relayer: relayerAddr,
 			outpace: coreAddr,
+			registry: registryAddr,
 			validUntil: blockTime + DAY_SECONDS,
 			feeTokenAddr: token.address,
 			feeTokenAmount: 0
@@ -505,6 +507,7 @@ contract('Identity', function(accounts) {
 			identityContract: id.address,
 			relayer: relayerAddr,
 			outpace: coreAddr,
+			registry: registryAddr,
 			validUntil: blockTime + DAY_SECONDS * 4,
 			feeTokenAddr: token.address,
 			feeTokenAmount: 0

--- a/test/TestIdentity.js
+++ b/test/TestIdentity.js
@@ -84,7 +84,7 @@ contract('Identity', function(accounts) {
 			registry: registryAddr,
 			validUntil: 1900000000,
 			feeTokenAddr: token.address,
-			feeTokenAmount: 0
+			feeAmount: 0
 		})
 		const bytecode = getProxyDeployBytecode(baseIdentityAddr, [[userAcc, 3]], {
 			routineAuthorizations: [defaultAuth.hash()],
@@ -202,7 +202,7 @@ contract('Identity', function(accounts) {
 			identityContract: id.address,
 			nonce: initialNonce,
 			feeTokenAddr: token.address,
-			feeTokenAmount: 25,
+			feeAmount: 25,
 			to: id.address,
 			data: idInterface.functions.setAddrPrivilege.encode([userAcc, 4])
 		})
@@ -225,7 +225,7 @@ contract('Identity', function(accounts) {
 		assert.equal(await id.privileges(userAcc), 4, 'privilege level changed')
 		assert.equal(
 			await token.balanceOf(relayerAddr),
-			initialBal.toNumber() + relayerTx.feeTokenAmount.toNumber(),
+			initialBal.toNumber() + relayerTx.feeAmount.toNumber(),
 			'relayer has received the tx fee'
 		)
 		assert.ok(
@@ -287,11 +287,11 @@ contract('Identity', function(accounts) {
 			identityContract: id.address,
 			nonce: initialNonce + i,
 			feeTokenAddr: token.address,
-			feeTokenAmount: 5,
+			feeAmount: 5,
 			to: id.address,
 			data: idInterface.functions.setAddrPrivilege.encode([userAcc, 4])
 		}))
-		const totalFee = txns.map(x => x.feeTokenAmount).reduce((a, b) => a + b, 0)
+		const totalFee = txns.map(x => x.feeAmount).reduce((a, b) => a + b, 0)
 
 		// Cannot use an invalid identityContract
 		const invalidTxns1 = [txns[0], { ...txns[1], identityContract: token.address }]
@@ -362,7 +362,7 @@ contract('Identity', function(accounts) {
 			registry: registryAddr,
 			validUntil: blockTime + DAY_SECONDS,
 			feeTokenAddr: token.address,
-			feeTokenAmount: fee
+			feeAmount: fee
 		})
 		// Activate this routine authorization
 		const tx = await zeroFeeTx(
@@ -557,7 +557,7 @@ contract('Identity', function(accounts) {
 			identityContract: id.address,
 			nonce: (await id.nonce()).toNumber(),
 			feeTokenAddr: token.address,
-			feeTokenAmount: 0,
+			feeAmount: 0,
 			to,
 			data
 		})

--- a/test/TestIdentity.js
+++ b/test/TestIdentity.js
@@ -59,7 +59,7 @@ contract('Identity', function(accounts) {
 		identityFactory = new Contract(idFactoryWeb3.address, IdentityFactory._json.abi, signer)
 
 		// deploy an Identity
-		const idWeb3 = await Identity.new([userAcc], [3], registryAddr)
+		const idWeb3 = await Identity.new([userAcc], [3])
 		id = new Contract(idWeb3.address, Identity._json.abi, signer)
 		await token.setBalanceTo(id.address, 10000)
 	})
@@ -73,7 +73,6 @@ contract('Identity', function(accounts) {
 			token.address,
 			relayerAddr,
 			feeAmnt,
-			registryAddr,
 			[[userAcc, 3]],
 			// Using this option is fine if the token.address is a token that reverts on failures
 			{ unsafeERC20: true, ...getStorageSlotsFromArtifact(Identity) }
@@ -122,7 +121,6 @@ contract('Identity', function(accounts) {
 			token.address,
 			relayerAddr,
 			0,
-			registryAddr,
 			[[userAcc, 3]],
 			{ unsafeERC20: true, ...getStorageSlotsFromArtifact(Identity) }
 		)

--- a/test/TestIdentity.js
+++ b/test/TestIdentity.js
@@ -30,15 +30,24 @@ const DAY_SECONDS = 24 * 60 * 60
 // READ THIS!
 // gasLimit must be hardcoded cause ganache cannot estimate it properly
 // that's cause of the call() that we do here; see https://github.com/AdExNetwork/adex-protocol-eth/issues/55
-const gasLimit = 300000
+const gasLimit = 400000
 
 contract('Identity', function(accounts) {
 	const idInterface = new Interface(Identity._json.abi)
+	// The Identity contract factory
 	let identityFactory
-	let id
+	// A dummy token
 	let token
+	// An instance of the AdExCore (OUTPACE) contract
 	let coreAddr
+	// the registry that's used in the RoutineAuthorizations
 	let registryAddr
+	// an Identity contract that will be used as a base for all proxies
+	let baseIdentityAddr
+	// default RoutineAuthorization that's valid forever
+	let defaultAuth
+	// The Identity contract instance that will be used
+	let id
 
 	const relayerAddr = accounts[3]
 	const userAcc = accounts[4]
@@ -64,8 +73,35 @@ contract('Identity', function(accounts) {
 		identityFactory = new Contract(idFactoryWeb3.address, IdentityFactory._json.abi, signer)
 
 		// deploy an Identity
-		const idWeb3 = await Identity.new([userAcc], [3])
-		id = new Contract(idWeb3.address, Identity._json.abi, signer)
+		const idWeb3 = await Identity.new([], [])
+		baseIdentityAddr = idWeb3.address
+
+		// We use this default RoutineAuthorization
+		// for various tests
+		defaultAuth = new RoutineAuthorization({
+			relayer: relayerAddr,
+			outpace: coreAddr,
+			registry: registryAddr,
+			validUntil: 1900000000,
+			feeTokenAddr: token.address,
+			feeTokenAmount: 0
+		})
+		const deployTx = getProxyDeployTx(
+			baseIdentityAddr,
+			token.address,
+			relayerAddr,
+			0,
+			[[userAcc, 3]],
+			{
+				unsafeERC20: true,
+				routineAuthorizations: [defaultAuth.hash()],
+				...getStorageSlotsFromArtifact(Identity)
+			}
+		)
+		const receipt = await (await identityFactory.deploy(deployTx.data, 0, { gasLimit })).wait()
+		const deployedEv = receipt.events.find(x => x.event === 'LogDeployed')
+		id = new Contract(deployedEv.args.addr, Identity._json.abi, signer)
+
 		await token.setBalanceTo(id.address, 10000)
 	})
 
@@ -74,7 +110,7 @@ contract('Identity', function(accounts) {
 
 		// Generating a proxy deploy transaction
 		const deployTx = getProxyDeployTx(
-			id.address,
+			baseIdentityAddr,
 			token.address,
 			relayerAddr,
 			feeAmnt,
@@ -149,7 +185,7 @@ contract('Identity', function(accounts) {
 		)
 
 		// No tokens, should revert
-		await expectEVMError(deployAndFund())
+		await expectEVMError(deployAndFund(), 'INSUFFICIENT_FUNDS')
 
 		// Set tokens
 		await token.setBalanceTo(identityFactory.address, fundAmnt)
@@ -170,8 +206,6 @@ contract('Identity', function(accounts) {
 
 		const initialBal = await token.balanceOf(relayerAddr)
 		const initialNonce = (await id.nonce()).toNumber()
-		// @TODO: multiple transactions (a few consecutive)
-		// @TODO consider testing that using multiple feeTokenAddr's will fail
 		const relayerTx = new Transaction({
 			identityContract: id.address,
 			nonce: initialNonce,
@@ -216,14 +250,11 @@ contract('Identity', function(accounts) {
 		await expectEVMError(id.execute([relayerTx.toSolidityTuple()], [sig]), 'WRONG_NONCE')
 
 		// Try to downgrade the privilege: should not be allowed
-		const relayerNextTx = new Transaction({
-			identityContract: id.address,
-			nonce: (await id.nonce()).toNumber(),
-			feeTokenAddr: token.address,
-			feeTokenAmount: 5,
-			to: id.address,
-			data: idInterface.functions.setAddrPrivilege.encode([userAcc, 1])
-		})
+		const relayerNextTx = await zeroFeeTx(
+			id.address,
+			idInterface.functions.setAddrPrivilege.encode([userAcc, 1])
+		)
+
 		const newHash = relayerNextTx.hashHex()
 		const newSig = splitSig(await ethSign(newHash, userAcc))
 		await expectEVMError(
@@ -232,14 +263,10 @@ contract('Identity', function(accounts) {
 		)
 
 		// Try to run a TX from an acc with insufficient privilege
-		const relayerTxEvil = new Transaction({
-			identityContract: id.address,
-			nonce: (await id.nonce()).toNumber(),
-			feeTokenAddr: token.address,
-			feeTokenAmount: 25,
-			to: id.address,
-			data: idInterface.functions.setAddrPrivilege.encode([evilAcc, 4])
-		})
+		const relayerTxEvil = await zeroFeeTx(
+			id.address,
+			idInterface.functions.setAddrPrivilege.encode([evilAcc, 4])
+		)
 		const hashEvil = relayerTxEvil.hashHex()
 		const sigEvil = splitSig(await ethSign(hashEvil, evilAcc))
 		await expectEVMError(
@@ -306,15 +333,10 @@ contract('Identity', function(accounts) {
 	})
 
 	it('execute by sender', async function() {
-		const initialNonce = (await id.nonce()).toNumber()
-		const relayerTx = new Transaction({
-			identityContract: id.address,
-			nonce: initialNonce,
-			feeTokenAddr: token.address,
-			feeTokenAmount: 0,
-			to: id.address,
-			data: idInterface.functions.setAddrPrivilege.encode([userAcc, 4])
-		})
+		const relayerTx = await zeroFeeTx(
+			id.address,
+			idInterface.functions.setAddrPrivilege.encode([userAcc, 4])
+		)
 
 		await expectEVMError(
 			id.executeBySender([relayerTx.toSolidityTuple()]),
@@ -330,7 +352,11 @@ contract('Identity', function(accounts) {
 			gasLimit
 		})).wait()
 		assert.equal(receipt.events.length, 1, 'right number of events emitted')
-		assert.equal((await id.nonce()).toNumber(), initialNonce + 1, 'nonce has increased with 1')
+		assert.equal(
+			(await id.nonce()).toNumber(),
+			parseInt(relayerTx.nonce, 10) + 1,
+			'nonce has increased with 1'
+		)
 	})
 
 	it('relay routine operations', async function() {
@@ -339,7 +365,6 @@ contract('Identity', function(accounts) {
 		const fee = 20
 		const blockTime = (await web3.eth.getBlock('latest')).timestamp
 		const auth = new RoutineAuthorization({
-			identityContract: id.address,
 			relayer: relayerAddr,
 			outpace: coreAddr,
 			registry: registryAddr,
@@ -347,14 +372,18 @@ contract('Identity', function(accounts) {
 			feeTokenAddr: token.address,
 			feeTokenAmount: fee
 		})
-		const hash = auth.hashHex()
-		const sig = splitSig(await ethSign(hash, userAcc))
+		// Activate this routine authorization
+		const tx = await zeroFeeTx(
+			id.address,
+			idInterface.functions.setRoutineAuth.encode([auth.hashHex(), true])
+		)
+		const sig = splitSig(await ethSign(tx.hashHex(), userAcc))
+		await (await id.execute([tx.toSolidityTuple()], [sig], { gasLimit })).wait()
+		// Create the operation and relay it
 		const op = RoutineOps.withdraw(token.address, userAcc, toWithdraw)
 		const initialUserBal = await token.balanceOf(userAcc)
 		const initialRelayerBal = await token.balanceOf(relayerAddr)
-		const execRoutines = id.executeRoutines.bind(id, auth.toSolidityTuple(), sig, [op], {
-			gasLimit
-		})
+		const execRoutines = id.executeRoutines.bind(id, auth.toSolidityTuple(), [op], { gasLimit })
 		const receipt = await (await execRoutines()).wait()
 		// console.log(receipt.gasUsed.toString(10))
 
@@ -384,31 +413,30 @@ contract('Identity', function(accounts) {
 			'relayer has received the fee only once'
 		)
 
-		// Does not work with an invalid sig
-		const invalidSig = splitSig(await ethSign(hash, evilAcc))
+		// Does not work with an invalid routine auth
+		const invalidAuth1 = new RoutineAuthorization({ ...auth, registry: userAcc })
+		await expectEVMError(id.executeRoutines(invalidAuth1.toSolidityTuple(), [op]), 'NOT_AUTHORIZED')
+		const invalidAuth2 = new RoutineAuthorization({ ...auth, relayer: userAcc })
 		await expectEVMError(
-			id.executeRoutines(auth.toSolidityTuple(), invalidSig, [op]),
-			'INSUFFICIENT_PRIVILEGE'
+			id.executeRoutines(invalidAuth2.toSolidityTuple(), [op]),
+			'ONLY_RELAYER_CAN_CALL'
 		)
 
 		// Does not allow withdrawals to an unauthorized addr
 		const evilOp = RoutineOps.withdraw(token.address, evilAcc, toWithdraw)
 		await expectEVMError(
-			id.executeRoutines(auth.toSolidityTuple(), sig, [evilOp]),
+			id.executeRoutines(auth.toSolidityTuple(), [evilOp]),
 			'INSUFFICIENT_PRIVILEGE_WITHDRAW'
 		)
 
 		// We can't tamper with authentication params (outpace in this case)
 		const evilTuple = auth.toSolidityTuple()
 		evilTuple[2] = token.address // set any other address
-		await expectEVMError(id.executeRoutines(evilTuple, sig, [op]), 'INSUFFICIENT_PRIVILEGE')
+		await expectEVMError(id.executeRoutines(evilTuple, [op]), 'NOT_AUTHORIZED')
 
 		// We can no longer call after the authorization has expired
 		await moveTime(web3, DAY_SECONDS + 10)
-		await expectEVMError(
-			id.executeRoutines(auth.toSolidityTuple(), sig, [op]),
-			'AUTHORIZATION_EXPIRED'
-		)
+		await expectEVMError(id.executeRoutines(auth.toSolidityTuple(), [op]), 'AUTHORIZATION_EXPIRED')
 	})
 
 	it('open a channel, withdraw via routines', async function() {
@@ -426,14 +454,10 @@ contract('Identity', function(accounts) {
 			0
 		)
 		const coreInterface = new Interface(AdExCore._json.abi)
-		const relayerTx = new Transaction({
-			identityContract: id.address,
-			nonce: (await id.nonce()).toNumber(),
-			feeTokenAddr: token.address,
-			feeTokenAmount: 0,
-			to: coreAddr,
-			data: coreInterface.functions.channelOpen.encode([channel.toSolidityTuple()])
-		})
+		const relayerTx = await zeroFeeTx(
+			coreAddr,
+			coreInterface.functions.channelOpen.encode([channel.toSolidityTuple()])
+		)
 		const hash = relayerTx.hashHex()
 		const sig = splitSig(await ethSign(hash, userAcc))
 		await (await id.execute([relayerTx.toSolidityTuple()], [sig], {
@@ -450,21 +474,9 @@ contract('Identity', function(accounts) {
 		const hashToSignHex = channel.hashToSignHex(coreAddr, stateRoot)
 		const vsig1 = splitSig(await ethSign(hashToSignHex, accounts[0]))
 		const vsig2 = splitSig(await ethSign(hashToSignHex, accounts[1]))
-		// Routine auth to withdraw
-		const auth = new RoutineAuthorization({
-			identityContract: id.address,
-			relayer: relayerAddr,
-			outpace: coreAddr,
-			registry: registryAddr,
-			validUntil: blockTime + DAY_SECONDS,
-			feeTokenAddr: token.address,
-			feeTokenAmount: 0
-		})
 		const balBefore = (await token.balanceOf(userAcc)).toNumber()
-		const authSig = splitSig(await ethSign(auth.hashHex(), userAcc))
 		const routineReceipt = await (await id.executeRoutines(
-			auth.toSolidityTuple(),
-			authSig,
+			defaultAuth.toSolidityTuple(),
 			[
 				RoutineOps.channelWithdraw([
 					channel.toSolidityTuple(),
@@ -491,7 +503,7 @@ contract('Identity', function(accounts) {
 			tokenAmnt
 		]
 		await expectEVMError(
-			id.executeRoutines(auth.toSolidityTuple(), authSig, [
+			id.executeRoutines(defaultAuth.toSolidityTuple(), [
 				RoutineOps.channelWithdraw(wrongWithdrawArgs)
 			]),
 			'NOT_SIGNED_BY_VALIDATORS'
@@ -503,17 +515,7 @@ contract('Identity', function(accounts) {
 		const tokenAmnt = 1066
 		await token.setBalanceTo(id.address, tokenAmnt)
 
-		const auth = new RoutineAuthorization({
-			identityContract: id.address,
-			relayer: relayerAddr,
-			outpace: coreAddr,
-			registry: registryAddr,
-			validUntil: blockTime + DAY_SECONDS * 4,
-			feeTokenAddr: token.address,
-			feeTokenAmount: 0
-		})
-		const authSig = splitSig(await ethSign(auth.hashHex(), userAcc))
-		const executeRoutines = id.executeRoutines.bind(id, auth.toSolidityTuple(), authSig)
+		const executeRoutines = id.executeRoutines.bind(id, defaultAuth.toSolidityTuple())
 
 		// a channel with non-whitelisted validators
 		const channelEvil = sampleChannel(
@@ -525,7 +527,7 @@ contract('Identity', function(accounts) {
 			0
 		)
 		await expectEVMError(
-			executeRoutines([RoutineOps.channelOpen([channelEvil.toSolidityTuple()])]),
+			executeRoutines([RoutineOps.channelOpen([channelEvil.toSolidityTuple()])], { gasLimit }),
 			'VALIDATOR_NOT_WHITELISTED'
 		)
 
@@ -540,9 +542,7 @@ contract('Identity', function(accounts) {
 		)
 		const receipt = await (await executeRoutines(
 			[RoutineOps.channelOpen([channel.toSolidityTuple()])],
-			{
-				gasLimit
-			}
+			{ gasLimit }
 		)).wait()
 		// events should be: transfer, channelOpen
 		assert.ok(receipt.events.length, 2, 'Transfer, ChannelOpen events emitted')
@@ -559,4 +559,15 @@ contract('Identity', function(accounts) {
 		assert.equal(expiredReceipt.events.length, 2, 'right event count')
 		assert.equal(await token.balanceOf(id.address), tokenAmnt, 'full deposit refunded')
 	})
+
+	async function zeroFeeTx(to, data) {
+		return new Transaction({
+			identityContract: id.address,
+			nonce: (await id.nonce()).toNumber(),
+			feeTokenAddr: token.address,
+			feeTokenAmount: 0,
+			to,
+			data
+		})
+	}
 })

--- a/test/mocks/Token.sol
+++ b/test/mocks/Token.sol
@@ -12,6 +12,7 @@ contract Token {
 	}
 
 	function transfer(address to, uint value) public returns (bool) {
+		require(balances[msg.sender] >= value, 'INSUFFICIENT_FUNDS');
 		balances[msg.sender] = SafeMath.sub(balances[msg.sender], value);
 		balances[to] = SafeMath.add(balances[to], value);
 		emit Transfer(msg.sender, to, value);
@@ -19,6 +20,7 @@ contract Token {
 	}
 
 	function transferFrom(address from, address to, uint value) public returns (bool) {
+		require(balances[from] >= value, 'INSUFFICIENT_FUNDS');
 		balances[from] = SafeMath.sub(balances[from], value);
 		balances[to] = SafeMath.add(balances[to], value);
 		emit Transfer(from, to, value);

--- a/test/mocks/Token.sol
+++ b/test/mocks/Token.sol
@@ -4,6 +4,8 @@ import "../../contracts/libs/SafeMath.sol";
 
 contract Token {
 	mapping (address => uint) balances;
+	// The approvals are pretty much dummy; they're not used in transferFrom
+	mapping (address => uint) approvals;
 	event Transfer(address indexed from, address indexed to, uint value);
 	function balanceOf(address owner) public view returns (uint) {
 		return balances[owner];
@@ -22,7 +24,10 @@ contract Token {
 		emit Transfer(from, to, value);
 		return true;
 	}
-
+	function approve(address spender, uint value) public returns (bool) {
+		approvals[spender] = value;
+		return true;
+	}
 	function setBalanceTo(address to, uint value) public {
 		balances[to] = value;
 	}


### PR DESCRIPTION
The authorization hash is now stored on-chain

This has the following advantages:

* Cheaper execution of routine operations (no need of signature verification)
* Routine authorizations can now be revoked
* Routine authorizations stay valid even if you revoke the wallet that created it
* setting/removing authorizations will now implicitly require a `Transactions` privilege level; this is critical for security, because routine authorizations contain `outpace` and `registry` addresses

a disadvantage is that routine authorizations need to be created through an on-chain tx, but that can be relayed via `execute`; so from the PoV of the front-end it's the same

another change is that the `channelOpen` routine operation will now call into `approve` of the token