### PR TITLE
deployAndExecute

### DIFF
--- a/contracts/IdentityFactory.sol
+++ b/contracts/IdentityFactory.sol
@@ -1,6 +1,8 @@
 pragma solidity ^0.5.6;
+pragma experimental ABIEncoderV2;
 
 import "./libs/SafeERC20.sol";
+import "./Identity.sol";
 
 contract IdentityFactory {
 	event LogDeployed(address addr, uint256 salt);
@@ -23,6 +25,14 @@ contract IdentityFactory {
 		assembly { addr := create2(0, add(code, 0x20), mload(code), salt) }
 		require(addr != address(0), "FAILED_DEPLOYING");
 		SafeERC20.transfer(tokenAddr, addr, tokenAmount);
+		emit LogDeployed(addr, salt);
+	}
+
+	function deployAndExecute(bytes memory code, uint256 salt, Identity.Transaction[] memory txns, bytes32[3][] memory signatures) public {
+		address addr;
+		assembly { addr := create2(0, add(code, 0x20), mload(code), salt) }
+		require(addr != address(0), "FAILED_DEPLOYING");
+		Identity(addr).execute(txns, signatures);
 		emit LogDeployed(addr, salt);
 	}
 }

--- a/contracts/IdentityFactory.sol
+++ b/contracts/IdentityFactory.sol
@@ -35,4 +35,9 @@ contract IdentityFactory {
 		Identity(addr).execute(txns, signatures);
 		emit LogDeployed(addr, salt);
 	}
+
+	function withdraw(address tokenAddr, address to, uint256 tokenAmount) public {
+		require(msg.sender == relayer, "ONLY_RELAYER");
+		SafeERC20.transfer(tokenAddr, to, tokenAmount);
+	}
 }

--- a/test/TestIdentity.js
+++ b/test/TestIdentity.js
@@ -663,7 +663,18 @@ contract('Identity', function(accounts) {
 			'IdentityFactory balance is correct'
 		)
 
-		// Relyaer can withdraw the fee
+		// Only relayer allowed to withdraw
+		const identityFactoryEvil = new Contract(
+			identityFactory.address,
+			IdentityFactory._json.abi,
+			web3Provider.getSigner(evilAcc)
+		)
+		await expectEVMError(
+			identityFactoryEvil.withdraw(token.address, evilAcc, feeAmount, { gasLimit }),
+			'ONLY_RELAYER'
+		)
+
+		// Relayer can withdraw the fee
 		await (await identityFactory.withdraw(
 			token.address,
 			relayerAddr,

--- a/test/TestIdentity.js
+++ b/test/TestIdentity.js
@@ -350,16 +350,22 @@ contract('Identity', function(accounts) {
 
 		const invalidNonceTx = new Transaction({
 			...relayerTx,
-			nonce: relayerTx.nonce-1
+			nonce: relayerTx.nonce - 1
 		})
-		await expectEVMError(idWithSender.executeBySender([invalidNonceTx.toSolidityTuple()]), 'WRONG_NONCE')
+		await expectEVMError(
+			idWithSender.executeBySender([invalidNonceTx.toSolidityTuple()]),
+			'WRONG_NONCE'
+		)
 
 		const invalidPrivTx = new Transaction({
 			...relayerTx,
 			nonce: (await id.nonce()).toNumber(),
-			data: idInterface.functions.setAddrPrivilege.encode([userAcc, 1]),
+			data: idInterface.functions.setAddrPrivilege.encode([userAcc, 1])
 		})
-		await expectEVMError(idWithSender.executeBySender([invalidPrivTx.toSolidityTuple()]), 'PRIVILEGE_NOT_DOWNGRADED')
+		await expectEVMError(
+			idWithSender.executeBySender([invalidPrivTx.toSolidityTuple()]),
+			'PRIVILEGE_NOT_DOWNGRADED'
+		)
 	})
 
 	it('relay routine operations', async function() {
@@ -643,8 +649,16 @@ contract('Identity', function(accounts) {
 		)).wait()
 		// LogChannelWithdraw, Transfer (withdraw), Transfer (tx fee), LogDeployed
 		assert.equal(receipt.events.length, 4, 'proper events length')
-		assert.equal((await token.balanceOf(expectedAddr)).toNumber(), tokenAmnt - feeAmount, 'Identity balance is correct')
-		assert.equal((await token.balanceOf(identityFactory.address)).toNumber(), initialFactoryBal.toNumber() + feeAmount, 'relayer balance is correct')
+		assert.equal(
+			(await token.balanceOf(expectedAddr)).toNumber(),
+			tokenAmnt - feeAmount,
+			'Identity balance is correct'
+		)
+		assert.equal(
+			(await token.balanceOf(identityFactory.address)).toNumber(),
+			initialFactoryBal.toNumber() + feeAmount,
+			'relayer balance is correct'
+		)
 	})
 
 	async function zeroFeeTx(to, data) {

--- a/test/TestIdentity.js
+++ b/test/TestIdentity.js
@@ -345,7 +345,7 @@ contract('Identity', function(accounts) {
 		})).wait()
 		assert.equal(receipt.events.length, 1, 'right number of events emitted')
 
-    const initialNonce = parseInt(relayerTx.nonce, 10)
+		const initialNonce = parseInt(relayerTx.nonce, 10)
 		assert.equal((await id.nonce()).toNumber(), initialNonce + 1, 'nonce has increased with 1')
 
 		const invalidNonceTx = new Transaction({
@@ -573,6 +573,78 @@ contract('Identity', function(accounts) {
 		// LogWithdrawExpired and Transfer
 		assert.equal(expiredReceipt.events.length, 2, 'right event count')
 		assert.equal(await token.balanceOf(id.address), tokenAmnt, 'full deposit refunded')
+	})
+
+	it('IdentityFactory: deployAndExecute', async function() {
+		const channelCreatorAddr = accounts[7]
+		const signer = web3Provider.getSigner(channelCreatorAddr)
+
+		const tokenAmnt = 1000
+		const feeAmount = 120
+		await token.setBalanceTo(channelCreatorAddr, tokenAmnt)
+
+		const blockTime = (await web3.eth.getBlock('latest')).timestamp
+		const initialFactoryBal = await token.balanceOf(identityFactory.address)
+
+		const validators = accounts.slice(0, 2)
+		const channel = sampleChannel(
+			validators,
+			token.address,
+			channelCreatorAddr,
+			tokenAmnt,
+			blockTime + DAY_SECONDS,
+			0
+		)
+		const core = new Contract(coreAddr, AdExCore._json.abi, signer)
+		await (await core.channelOpen(channel.toSolidityTuple())).wait()
+
+		const bytecode = getProxyDeployBytecode(baseIdentityAddr, [[userAcc, 3]], {
+			...getStorageSlotsFromArtifact(Identity)
+		})
+
+		const salt = `0x${Buffer.from(randomBytes(32)).toString('hex')}`
+		const expectedAddr = getAddress(
+			`0x${generateAddress2(identityFactory.address, salt, bytecode).toString('hex')}`
+		)
+
+		// Prepare all the data needed for withdrawal
+		const elem1 = Channel.getBalanceLeaf(expectedAddr, tokenAmnt)
+		const tree = new MerkleTree([elem1])
+		const proof = tree.proof(elem1)
+		const stateRoot = tree.getRoot()
+		const hashToSignHex = channel.hashToSignHex(coreAddr, stateRoot)
+		const vsig1 = splitSig(await ethSign(hashToSignHex, validators[0]))
+		const vsig2 = splitSig(await ethSign(hashToSignHex, validators[1]))
+
+		const coreInterface = new Interface(AdExCore._json.abi)
+		const tx1 = new Transaction({
+			identityContract: expectedAddr,
+			nonce: 0,
+			feeTokenAddr: token.address,
+			// This fee would pay for the transaction AND for the deploy
+			feeAmount,
+			to: coreAddr,
+			data: coreInterface.functions.channelWithdraw.encode([
+				channel.toSolidityTuple(),
+				stateRoot,
+				[vsig1, vsig2],
+				proof,
+				tokenAmnt
+			])
+		})
+		const sig = splitSig(await ethSign(tx1.hashHex(), userAcc))
+
+		const receipt = await (await identityFactory.deployAndExecute(
+			bytecode,
+			salt,
+			[tx1.toSolidityTuple()],
+			[sig],
+			{ gasLimit }
+		)).wait()
+		// LogChannelWithdraw, Transfer (withdraw), Transfer (tx fee), LogDeployed
+		assert.equal(receipt.events.length, 4, 'proper events length')
+		assert.equal((await token.balanceOf(expectedAddr)).toNumber(), tokenAmnt - feeAmount, 'Identity balance is correct')
+		assert.equal((await token.balanceOf(identityFactory.address)).toNumber(), initialFactoryBal.toNumber() + feeAmount, 'relayer balance is correct')
 	})
 
 	async function zeroFeeTx(to, data) {


### PR DESCRIPTION
Fixes #67 

This PR adds:

* `deployAndExecute` to the factory, which allows to deploy a contract and immediately execute transactions on it
* this is useful for publishers which would earn funds before we deploy their identity; but once they do, we the realyer will, in 1 tx, deploy their identity, withdraw from a channel, and get their fee
* adds a `withdraw` to the factory, which is useful to drain funds from it