### PR TITLE
WIP: IdentityFactory: safer deploy

### DIFF
--- a/contracts/IdentityFactory.sol
+++ b/contracts/IdentityFactory.sol
@@ -38,26 +38,14 @@ contract IdentityFactory {
 	// This is done to mitigate possible frontruns where, for example, deploying the same code/salt via deploy()
 	// would make a pending deployAndFund fail
 	// The way we mitigate that is by checking if the contract is already deployed and if so, we continue execution
-	/*
 	function deploySafe(bytes memory code, uint256 salt) internal returns (address) {
-		address addr;
-		assembly { addr := create2(0, add(code, 0x20), mload(code), salt) }
-		if (addr == address(0)) {
-			address expectedAddr = address(uint160(uint256((keccak256(abi.encodePacked(byte(0xff), address(this), salt, keccak256(code)))))));
-			uint size;
-			assembly { size := extcodesize(expectedAddr) }
-			// If there is code at that address, we can assume it's the one we were about to deploy, 
-			// because of how CREATE2 and keccak256 works
-			// Deploying failed, but it's also not currently deployed
-			require(size > 0, "FAILED_DEPLOYING");
-			return expectedAddr;
-		}
-		return addr;
-	}*/
-	function deploySafe(bytes memory code, uint256 salt) internal returns (address) {
-		address expectedAddr = address(uint160(uint256(keccak256(abi.encodePacked(byte(0xff), address(this), salt, keccak256(code))))));
+		address expectedAddr = address(uint160(uint256(
+			keccak256(abi.encodePacked(byte(0xff), address(this), salt, keccak256(code)))
+		)));
 		uint size;
 		assembly { size := extcodesize(expectedAddr) }
+		// If there is code at that address, we can assume it's the one we were about to deploy,
+		// because of how CREATE2 and keccak256 works
 		if (size == 0) {
 			address addr;
 			assembly { addr := create2(0, add(code, 0x20), mload(code), salt) }

--- a/contracts/IdentityFactory.sol
+++ b/contracts/IdentityFactory.sol
@@ -13,25 +13,19 @@ contract IdentityFactory {
 	}
 
 	function deploy(bytes memory code, uint256 salt) public {
-		address addr;
-		assembly { addr := create2(0, add(code, 0x20), mload(code), salt) }
-		require(addr != address(0), "FAILED_DEPLOYING");
+		address addr = deploySafe(code, salt);
 		emit LogDeployed(addr, salt);
 	}
 
 	function deployAndFund(bytes memory code, uint256 salt, address tokenAddr, uint256 tokenAmount) public {
 		require(msg.sender == relayer, "ONLY_RELAYER");
-		address addr;
-		assembly { addr := create2(0, add(code, 0x20), mload(code), salt) }
-		require(addr != address(0), "FAILED_DEPLOYING");
+		address addr = deploySafe(code, salt);
 		SafeERC20.transfer(tokenAddr, addr, tokenAmount);
 		emit LogDeployed(addr, salt);
 	}
 
 	function deployAndExecute(bytes memory code, uint256 salt, Identity.Transaction[] memory txns, bytes32[3][] memory signatures) public {
-		address addr;
-		assembly { addr := create2(0, add(code, 0x20), mload(code), salt) }
-		require(addr != address(0), "FAILED_DEPLOYING");
+		address addr = deploySafe(code, salt);
 		Identity(addr).execute(txns, signatures);
 		emit LogDeployed(addr, salt);
 	}
@@ -39,5 +33,37 @@ contract IdentityFactory {
 	function withdraw(address tokenAddr, address to, uint256 tokenAmount) public {
 		require(msg.sender == relayer, "ONLY_RELAYER");
 		SafeERC20.transfer(tokenAddr, to, tokenAmount);
+	}
+
+	// This is done to mitigate possible frontruns where, for example, deploying the same code/salt via deploy()
+	// would make a pending deployAndFund fail
+	// The way we mitigate that is by checking if the contract is already deployed and if so, we continue execution
+	/*
+	function deploySafe(bytes memory code, uint256 salt) internal returns (address) {
+		address addr;
+		assembly { addr := create2(0, add(code, 0x20), mload(code), salt) }
+		if (addr == address(0)) {
+			address expectedAddr = address(uint160(uint256((keccak256(abi.encodePacked(byte(0xff), address(this), salt, keccak256(code)))))));
+			uint size;
+			assembly { size := extcodesize(expectedAddr) }
+			// If there is code at that address, we can assume it's the one we were about to deploy, 
+			// because of how CREATE2 and keccak256 works
+			// Deploying failed, but it's also not currently deployed
+			require(size > 0, "FAILED_DEPLOYING");
+			return expectedAddr;
+		}
+		return addr;
+	}*/
+	function deploySafe(bytes memory code, uint256 salt) internal returns (address) {
+		address expectedAddr = address(uint160(uint256((keccak256(abi.encodePacked(byte(0xff), address(this), salt, keccak256(code)))))));
+		uint size;
+		assembly { size := extcodesize(expectedAddr) }
+		if (size == 0) {
+			address addr;
+			assembly { addr := create2(0, add(code, 0x20), mload(code), salt) }
+			require(addr != address(0), "FAILED_DEPLOYING");
+			//assert(addr == expectedAddr);
+		}
+		return expectedAddr;
 	}
 }

--- a/contracts/IdentityFactory.sol
+++ b/contracts/IdentityFactory.sol
@@ -55,14 +55,14 @@ contract IdentityFactory {
 		return addr;
 	}*/
 	function deploySafe(bytes memory code, uint256 salt) internal returns (address) {
-		address expectedAddr = address(uint160(uint256((keccak256(abi.encodePacked(byte(0xff), address(this), salt, keccak256(code)))))));
+		address expectedAddr = address(uint160(uint256(keccak256(abi.encodePacked(byte(0xff), address(this), salt, keccak256(code))))));
 		uint size;
 		assembly { size := extcodesize(expectedAddr) }
 		if (size == 0) {
 			address addr;
 			assembly { addr := create2(0, add(code, 0x20), mload(code), salt) }
 			require(addr != address(0), "FAILED_DEPLOYING");
-			//assert(addr == expectedAddr);
+			require(addr == expectedAddr, "FAILED_MATCH");
 		}
 		return expectedAddr;
 	}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "adex-protocol-eth",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adex-protocol-eth",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "AdEx protocol on Ethereum",
   "directories": {
     "test": "test"

--- a/test/TestIdentity.js
+++ b/test/TestIdentity.js
@@ -182,8 +182,11 @@ contract('Identity', function(accounts) {
 		// Set tokens
 		await token.setBalanceTo(identityFactory.address, fundAmnt)
 
+		//console.log(await (await identityFactoryUser.deploy(bytecode, salt)))
+
 		// Call successfully
 		const receipt = await (await deployAndFund()).wait()
+		//console.log('gasUsed:', receipt.gasUsed.toString(10))
 		const deployedEv = receipt.events.find(x => x.event === 'LogDeployed')
 		assert.ok(deployedEv, 'has deployedEv')
 		assert.equal(


### PR DESCRIPTION
solves #70 

I also tried trying the deploy first, and checking for the code being there second; but this approach has a fundamental issue - `create2` will consume all the gas if it fails