### PR TITLE
Tests: fix tests execution by sticking with versions in package-lock.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ethers": "^4.0.27",
     "js-sha3": "^0.8.0",
     "solc": "0.5.6",
-    "truffle": "^5.0.26"
+    "truffle": "^5.0.10"
   },
   "devDependencies": {
     "eslint": "^5.16.0",


### PR DESCRIPTION
fix #75 

In package.json truffle package is required to be `^5.0.26` while in package-lock.json truffle is required to be `5.0.10` which makes npm upgrade all packages and fail to comply with locked versions.