### PR TITLE
New token audit

### DIFF
--- a/contracts/ADXFlashLoans.sol
+++ b/contracts/ADXFlashLoans.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity ^0.6.12;
+
+import "./libs/SafeERC20.sol";
+
+contract ADXFlashLoans {
+	// Very important that this contract does not have any storage
+	function flash(GeneralERC20 token, uint amount, address to, bytes memory data) public {
+		uint bal = token.balanceOf(address(this));
+		token.transfer(to, amount);
+		assembly {
+			let result := delegatecall(gas(), to, add(data, 0x20), mload(data), 0, 0)
+			switch result case 0 {
+				let size := returndatasize()
+				let ptr := mload(0x40)
+				returndatacopy(ptr, 0, size)
+				revert(ptr, size)
+			}
+			default {}
+		}
+		require(token.balanceOf(address(this)) == bal, 'FLASHLOAN_NOT_RETURNED');
+	}
+}
+
+

--- a/contracts/ADXToken.sol
+++ b/contracts/ADXToken.sol
@@ -15,8 +15,8 @@ contract ADXSupplyController {
 		require(governance[msg.sender] >= uint8(GovernanceLevel.Mint), 'NOT_GOVERNANCE');
 		// 10 August 2020
 		require(now > 1597017600, 'MINT_TOO_EARLY');
-		// 10 September 2020
 		uint totalSupplyAfter = SafeMath.add(token.totalSupply(), amount);
+		// 10 September 2020
 		if (now < 1599696000) {
 			// 50M * 10**18
 			require(totalSupplyAfter <= 50000000000000000000000000, 'EARLY_MINT_TOO_LARGE');

--- a/contracts/ADXToken.sol
+++ b/contracts/ADXToken.sol
@@ -4,25 +4,6 @@ pragma solidity ^0.6.12;
 import "./libs/SafeMath.sol";
 import "./libs/SafeERC20.sol";
 
-contract ADXFlashLoans {
-	// Very important that this contract does not have any storage
-	function flash(GeneralERC20 token, uint amount, address to, bytes memory data) public {
-		uint bal = token.balanceOf(address(this));
-		token.transfer(to, amount);
-		assembly {
-			let result := delegatecall(gas(), to, add(data, 0x20), mload(data), 0, 0)
-			switch result case 0 {
-				let size := returndatasize()
-				let ptr := mload(0x40)
-				returndatacopy(ptr, 0, size)
-				revert(ptr, size)
-			}
-			default {}
-		}
-		require(token.balanceOf(address(this)) == bal, 'FLASHLOAN_NOT_RETURNED');
-	}
-}
-
 contract ADXSupplyController {
 	enum GovernanceLevel { None, Mint, All }
 	mapping (address => uint8) governance;

--- a/contracts/ADXToken.sol
+++ b/contracts/ADXToken.sol
@@ -13,10 +13,17 @@ contract ADXSupplyController {
 
 	function mint(ADXToken token, address owner, uint amount) public {
 		require(governance[msg.sender] >= uint8(GovernanceLevel.Mint), 'NOT_GOVERNANCE');
-		// 150M * 10**18
-		require(SafeMath.add(token.totalSupply(), amount) <= 150000000000000000000000000, 'MINT_TOO_LARGE');
 		// 10 August 2020
 		require(now > 1597017600, 'MINT_TOO_EARLY');
+		// 10 September 2020
+		uint totalSupplyAfter = SafeMath.add(token.totalSupply(), amount);
+		if (now < 1599696000) {
+			// 50M * 10**18
+			require(totalSupplyAfter <= 50000000000000000000000000, 'EARLY_MINT_TOO_LARGE');
+		} else {
+			// 150M * 10**18
+			require(totalSupplyAfter <= 150000000000000000000000000, 'MINT_TOO_LARGE');
+		}
 		token.mint(owner, amount);
 	}
 


### PR DESCRIPTION
Implements two auditor suggestions
* move flash loans to a separate file
* only allow up to 50M ADX to be minted by the governance in the first month, allowing holders to migrate their ADX before that