### PR TITLE
Gas refunds

### DIFF
--- a/contracts/AdExCore.sol
+++ b/contracts/AdExCore.sol
@@ -64,6 +64,17 @@ contract AdExCore {
 		emit LogChannelWithdrawExpired(channelId, toWithdraw);
 	}
 
+	function channelRefundGas(ChannelLibrary.Channel memory channel, address[] memory users)
+		external
+	{
+		bytes32 channelId = channel.hash();
+		require(states[channelId] == ChannelLibrary.State.Expired, "INVALID_STATE");
+		delete withdrawn[channelId];
+		for (uint i=0; i<users.length; i++) {
+			delete withdrawnPerUser[channelId][users[i]];
+		}
+	}
+
 	function channelWithdraw(ChannelLibrary.Channel memory channel, bytes32 stateRoot, bytes32[3][] memory signatures, bytes32[] memory proof, uint amountInTree)
 		external
 	{

--- a/contracts/AdExCore.sol
+++ b/contracts/AdExCore.sol
@@ -69,6 +69,7 @@ contract AdExCore {
 	{
 		bytes32 channelId = channel.hash();
 		require(states[channelId] == ChannelLibrary.State.Expired, "INVALID_STATE");
+		require(msg.sender == channel.creator, "INVALID_CREATOR");
 		delete withdrawn[channelId];
 		for (uint i=0; i<users.length; i++) {
 			delete withdrawnPerUser[channelId][users[i]];

--- a/contracts/AdExCore.sol
+++ b/contracts/AdExCore.sol
@@ -30,9 +30,9 @@ contract AdExCore {
 	event LogChannelWithdrawExpired(bytes32 indexed channelId, uint amount);
 	event LogChannelWithdraw(bytes32 indexed channelId, uint amount);
 
-	// All functions are public
+	// All functions are external
 	function channelOpen(ChannelLibrary.Channel memory channel)
-		public
+		external
 	{
 		bytes32 channelId = channel.hash();
 		require(states[channelId] == ChannelLibrary.State.Unknown, "INVALID_STATE");
@@ -47,7 +47,7 @@ contract AdExCore {
 	}
 
 	function channelWithdrawExpired(ChannelLibrary.Channel memory channel)
-		public
+		external
 	{
 		bytes32 channelId = channel.hash();
 		require(states[channelId] == ChannelLibrary.State.Active, "INVALID_STATE");
@@ -65,7 +65,7 @@ contract AdExCore {
 	}
 
 	function channelWithdraw(ChannelLibrary.Channel memory channel, bytes32 stateRoot, bytes32[3][] memory signatures, bytes32[] memory proof, uint amountInTree)
-		public
+		external
 	{
 		bytes32 channelId = channel.hash();
 		require(states[channelId] == ChannelLibrary.State.Active, "INVALID_STATE");


### PR DESCRIPTION
Allows the channel creator to get a gas refund by deleting all unneeded storage slots used by the channel

**TODO**: decide whether we want to restrict it to the channel creator only
Cons: limits usecases
Pros: saves us from any random dapp exploiting this for profit