### PR TITLE
Wallet: zapper contract

### DIFF
--- a/contracts/interfaces/IUniV3SwapRouter.sol
+++ b/contracts/interfaces/IUniV3SwapRouter.sol
@@ -2,11 +2,9 @@
 pragma solidity >=0.7.5;
 pragma abicoder v2;
 
-import '@uniswap/v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol';
-
 /// @title Router token swapping functionality
 /// @notice Functions for swapping tokens via Uniswap V3
-interface ISwapRouter is IUniswapV3SwapCallback {
+interface ISwapRouter {
     struct ExactInputSingleParams {
         address tokenIn;
         address tokenOut;

--- a/contracts/interfaces/UniV3ISwapRouter.sol
+++ b/contracts/interfaces/UniV3ISwapRouter.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.7.5;
+pragma abicoder v2;
+
+import '@uniswap/v3-core/contracts/interfaces/callback/IUniswapV3SwapCallback.sol';
+
+/// @title Router token swapping functionality
+/// @notice Functions for swapping tokens via Uniswap V3
+interface ISwapRouter is IUniswapV3SwapCallback {
+    struct ExactInputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 deadline;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    /// @notice Swaps `amountIn` of one token for as much as possible of another token
+    /// @param params The parameters necessary for the swap, encoded as `ExactInputSingleParams` in calldata
+    /// @return amountOut The amount of the received token
+    function exactInputSingle(ExactInputSingleParams calldata params) external payable returns (uint256 amountOut);
+
+    struct ExactInputParams {
+        bytes path;
+        address recipient;
+        uint256 deadline;
+        uint256 amountIn;
+        uint256 amountOutMinimum;
+    }
+
+    /// @notice Swaps `amountIn` of one token for as much as possible of another along the specified path
+    /// @param params The parameters necessary for the multi-hop swap, encoded as `ExactInputParams` in calldata
+    /// @return amountOut The amount of the received token
+    function exactInput(ExactInputParams calldata params) external payable returns (uint256 amountOut);
+
+    struct ExactOutputSingleParams {
+        address tokenIn;
+        address tokenOut;
+        uint24 fee;
+        address recipient;
+        uint256 deadline;
+        uint256 amountOut;
+        uint256 amountInMaximum;
+        uint160 sqrtPriceLimitX96;
+    }
+
+    /// @notice Swaps as little as possible of one token for `amountOut` of another token
+    /// @param params The parameters necessary for the swap, encoded as `ExactOutputSingleParams` in calldata
+    /// @return amountIn The amount of the input token
+    function exactOutputSingle(ExactOutputSingleParams calldata params) external payable returns (uint256 amountIn);
+
+    struct ExactOutputParams {
+        bytes path;
+        address recipient;
+        uint256 deadline;
+        uint256 amountOut;
+        uint256 amountInMaximum;
+    }
+
+    /// @notice Swaps as little as possible of one token for `amountOut` of another along the specified path (reversed)
+    /// @param params The parameters necessary for the multi-hop swap, encoded as `ExactOutputParams` in calldata
+    /// @return amountIn The amount of the input token
+    function exactOutput(ExactOutputParams calldata params) external payable returns (uint256 amountIn);
+}

--- a/contracts/wallet/Zapper.sol
+++ b/contracts/wallet/Zapper.sol
@@ -80,8 +80,6 @@ contract WalletZapper {
 		for (uint i=0; i!=assetsToUnwrap.length; i++) {
 			lendingPool.withdraw(assetsToUnwrap[i], type(uint256).max, address(this));
 		}
-		// @TODO: unwrap
-		// @TODO: should those be vars
 		address to = msg.sender;
 		uint deadline = block.timestamp;
 		// @TODO: should trades.length be assigned to a local var? if so, should this be applied to other places in v5 as well?
@@ -108,5 +106,21 @@ contract WalletZapper {
 		for (uint i=0; i!=assetsToUnwrap.length; i++) {
 			lendingPool.withdraw(assetsToUnwrap[i], type(uint256).max, msg.sender);
 		}
+	}
+
+	// V3
+	function tradeV3(address uniV3Router, address tokenIn, address tokenOut, uint amount, uint minOut) external {
+		ISwapRouter().exactInputSingle(
+		    ISwapRouter(uniV3Router).ExactInputSingleParams (
+			tokenIn,
+			tokenOut,
+			3000, // @TODO
+			msg.sender,
+			block.timestamp,
+			amount,
+			minOut,
+			0
+		    )
+		);
 	}
 }

--- a/contracts/wallet/Zapper.sol
+++ b/contracts/wallet/Zapper.sol
@@ -10,8 +10,56 @@ interface IAaveLendingPool {
   ) external;
 }
 
+// Full interface here: https://github.com/Uniswap/uniswap-v2-periphery/blob/master/contracts/interfaces/IUniswapV2Router01.sol
+interface IUniswapSimple {
+        function WETH() external pure returns (address);
+        function swapTokensForExactTokens(
+                uint amountOut,
+                uint amountInMax,
+                address[] calldata path,
+                address to,
+                uint deadline
+        ) external returns (uint[] memory amounts);
+	function swapExactTokensForTokens(
+		uint amountIn,
+		uint amountOutMin,
+		address[] calldata path,
+		address to,
+		uint deadline
+	) external returns (uint[] memory amounts);
+}
+
+
 contract WalletZapper {
-	function exchange() external {
+	// @TODO: constructor
+
+
+	struct Trade {
+		IUniswapSimple router;
+		// @TODO should there be a trade type
+		uint amountIn;
+		uint amountOutMin;
+		address[] path;
+		bool wrap;
+	}
+
+	function exchange(address[] calldata assetsToUnwrap, Trade[] memory trades) external {
+		// @TODO: unwrap
+		// @TODO: should those be vars
+		address to = msg.sender;
+		uint deadline = block.timestamp;
+		// @TODO: should trades.length be assigned to a local var? if so, should this be applied to other places in v5 as well?
+		for (uint i=0; i!=trades.length; i++) {
+			Trade memory trade = trades[i];
+			if (!trade.wrap) {
+				trade.router.swapExactTokensForTokens(trade.amountIn, trade.amountOutMin, trade.path, to, deadline);
+			} else {
+				trade.router.swapExactTokensForTokens(trade.amountIn, trade.amountOutMin, trade.path, address(this), deadline);
+				// @TODO aaveLendingPool.deposit(trade.path[last], outAmount, to, refCode);
+			}
+		}
+		// @TODO: wrapping
+
 	}
 
 	function wrapLending() external {

--- a/contracts/wallet/Zapper.sol
+++ b/contracts/wallet/Zapper.sol
@@ -184,6 +184,10 @@ contract WalletZapper {
 		}
 
 		require(totalAllocPts == 1000, "ALLOC_PTS");
+	}
 
+	function recoverFunds(IERC20 token, uint amount) external {
+		require(msg.sender == admin, "NOT_ADMIN");
+		token.transfer(admin, amount);
 	}
 }

--- a/contracts/wallet/Zapper.sol
+++ b/contracts/wallet/Zapper.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.8.1;
 
 import "../interfaces/IERC20.sol";
+import "../interfaces/IUniV3SwapRouter.sol";
 
 interface IAaveLendingPool {
   function deposit(
@@ -108,10 +109,15 @@ contract WalletZapper {
 		}
 	}
 
+	// wrpap WETH
+	function wrapETH() payable external {
+		payable(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2).transfer(msg.value);
+	}
+
 	// V3
 	function tradeV3(address uniV3Router, address tokenIn, address tokenOut, uint amount, uint minOut) external {
-		ISwapRouter().exactInputSingle(
-		    ISwapRouter(uniV3Router).ExactInputSingleParams (
+		ISwapRouter(uniV3Router).exactInputSingle(
+		    ISwapRouter.ExactInputSingleParams (
 			tokenIn,
 			tokenOut,
 			3000, // @TODO

--- a/contracts/wallet/Zapper.sol
+++ b/contracts/wallet/Zapper.sol
@@ -67,13 +67,13 @@ contract WalletZapper {
 	mapping (address => bool) allowedSpenders;
 	IAaveLendingPool public lendingPool;
 	uint16 aaveRefCode;
-	constructor(IAaveLendingPool _lendingPool, uint16 _aaveRefCode, address[] allowedSpenders) {
+	constructor(IAaveLendingPool _lendingPool, uint16 _aaveRefCode, address[] memory spenders) {
 		admin = msg.sender;
 		lendingPool = _lendingPool;
 		aaveRefCode = _aaveRefCode;
 		allowedSpenders[address(_lendingPool)] = true;
-		for (uint i=0; i!=allowedSpenders.length; i++) {
-			allowedSpenders[allowedSpenders[i]] = true;
+		for (uint i=0; i!=spenders.length; i++) {
+			allowedSpenders[spenders[i]] = true;
 		}
 	}
 
@@ -124,21 +124,11 @@ contract WalletZapper {
 	}
 
 	// Uniswap V3
-	// @TODO: multi-path trade
-	// @TODO: perhaps simplify this by just making it a proxy to uniV3Router and passing in the whole struct
-	function tradeV3(ISwapRouter uniV3Router, address tokenIn, address tokenOut, uint amount, uint minOut) external returns (uint) {
-		return uniV3Router.exactInputSingle(
-		    ISwapRouter.ExactInputSingleParams (
-			tokenIn,
-			tokenOut,
-			3000, // @TODO
-			msg.sender,
-			block.timestamp,
-			amount,
-			minOut,
-			0
-		    )
-		);
+	function tradeV3(ISwapRouter uniV3Router, ISwapRouter.ExactInputParams calldata params) external returns (uint) {
+		return uniV3Router.exactInput(params);
+	}
+	function tradeV3Single(ISwapRouter uniV3Router, ISwapRouter.ExactInputSingleParams calldata params) external returns (uint) {
+		return uniV3Router.exactInputSingle(params);
 	}
 
 	// @TODO logs/return output amounts?

--- a/contracts/wallet/Zapper.sol
+++ b/contracts/wallet/Zapper.sol
@@ -57,8 +57,8 @@ contract WalletZapper {
 
 	address constant WETH = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
 
-	address admin;
-	mapping (address => bool) allowedSpenders;
+	address public admin;
+	mapping (address => bool) public allowedSpenders;
 	IAaveLendingPool public lendingPool;
 	uint16 aaveRefCode;
 	constructor(IAaveLendingPool _lendingPool, uint16 _aaveRefCode, address[] memory spenders) {
@@ -129,7 +129,7 @@ contract WalletZapper {
 		return uniV3Router.exactInputSingle(params);
 	}
 
-	// @TODO: unwrap input
+	// @TODO: unwrap input from aToken?
 	function diversifyV3(ISwapRouter uniV3Router, address inputAsset, uint24 inputFee, uint inputMinOut, DiversificationTrade[] memory trades) external {
 		uint inputAmount;
 		if (inputAsset != address(0)) {

--- a/contracts/wallet/Zapper.sol
+++ b/contracts/wallet/Zapper.sol
@@ -49,6 +49,7 @@ contract WalletZapper {
 	}
 	struct DiversificationTrade {
 		address tokenOut;
+		uint24 fee;
 		uint allocPts;
 		uint amountOutMin;
 		bool wrap;
@@ -128,19 +129,19 @@ contract WalletZapper {
 		return uniV3Router.exactInputSingle(params);
 	}
 
-	// @TODO logs/return output amounts?
-	function diversifyV3(ISwapRouter uniV3Router, address inputAsset, DiversificationTrade[] memory trades) external {
+	// @TODO: unwrap input
+	function diversifyV3(ISwapRouter uniV3Router, address inputAsset, uint24 inputFee, uint inputMinOut, DiversificationTrade[] memory trades) external {
 		uint inputAmount;
 		if (inputAsset != address(0)) {
 			inputAmount = uniV3Router.exactInputSingle(
 			    ISwapRouter.ExactInputSingleParams (
 				inputAsset,
 				WETH,
-				3000, // @TODO
+				inputFee,
 				address(this),
 				block.timestamp,
 				IERC20(inputAsset).balanceOf(address(this)),
-				0, // @TODO minOut
+				inputMinOut,
 				0
 			    )
 			);
@@ -158,7 +159,7 @@ contract WalletZapper {
 				    ISwapRouter.ExactInputSingleParams (
 					WETH,
 					trade.tokenOut,
-					3000, // @TODO
+					trade.fee,
 					msg.sender,
 					block.timestamp,
 					inputAmount * trade.allocPts / 1000,
@@ -171,7 +172,7 @@ contract WalletZapper {
 				    ISwapRouter.ExactInputSingleParams (
 					WETH,
 					trade.tokenOut,
-					3000, // @TODO
+					trade.fee,
 					address(this),
 					block.timestamp,
 					inputAmount * trade.allocPts / 1000,

--- a/contracts/wallet/Zapper.sol
+++ b/contracts/wallet/Zapper.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.8.1;
+
+interface IAaveLendingPool {
+  function deposit(
+    address asset,
+    uint256 amount,
+    address onBehalfOf,
+    uint16 referralCode
+  ) external;
+}
+
+contract WalletZapper {
+	function exchange() external {
+	}
+
+	function wrapLending() external {
+	}
+}

--- a/contracts/wallet/Zapper.sol
+++ b/contracts/wallet/Zapper.sol
@@ -31,8 +31,14 @@ interface IUniswapSimple {
 
 
 contract WalletZapper {
-	// @TODO: constructor
-
+	// @TODO: is it only one lending pool?
+	IAaveLendingPool public lendingPool;
+	uint16 refCode;
+	constructor(IAaveLendingPool _lendingPool, uint16 _refCode) {
+		lendingPool = _lendingPool;
+		refCode = _refCode;
+		// @TODO approvals
+	}
 
 	struct Trade {
 		IUniswapSimple router;
@@ -44,6 +50,8 @@ contract WalletZapper {
 	}
 
 	function exchange(address[] calldata assetsToUnwrap, Trade[] memory trades) external {
+		//for (uint i=0; i!=assetsToUnwrap.length; i++) {
+		//}
 		// @TODO: unwrap
 		// @TODO: should those be vars
 		address to = msg.sender;
@@ -54,8 +62,9 @@ contract WalletZapper {
 			if (!trade.wrap) {
 				trade.router.swapExactTokensForTokens(trade.amountIn, trade.amountOutMin, trade.path, to, deadline);
 			} else {
-				trade.router.swapExactTokensForTokens(trade.amountIn, trade.amountOutMin, trade.path, address(this), deadline);
-				// @TODO aaveLendingPool.deposit(trade.path[last], outAmount, to, refCode);
+				uint[] memory amounts = trade.router.swapExactTokensForTokens(trade.amountIn, trade.amountOutMin, trade.path, address(this), deadline);
+				uint lastIdx = trade.path.length - 1;
+				lendingPool.deposit(trade.path[lastIdx], amounts[lastIdx], to, refCode);
 			}
 		}
 		// @TODO: wrapping

--- a/contracts/wallet/Zapper.sol
+++ b/contracts/wallet/Zapper.sol
@@ -36,7 +36,8 @@ interface IUniswapSimple {
 	) external returns (uint[] memory amounts);
 }
 
-
+// Decisions: will start with aave over compound (easier API - has `onBehalfOf`, referrals), compound can be added later if needed
+// uni v3 needs to be supported since it's proving that it's efficient and the router is different
 contract WalletZapper {
 	// @TODO: is it only one lending pool?
 	IAaveLendingPool public lendingPool;
@@ -56,6 +57,13 @@ contract WalletZapper {
 		bool wrap;
 	}
 
+	// @TODO an additional approve router function (onlyOwner)
+	function approve(address token, address spender) public {
+		// require onlyOwner
+		IERC20(token).approve(spender, type(uint256).max);
+	}
+
+	// @TODO: return all the outputs from this?
 	function exchange(address[] calldata assetsToUnwrap, Trade[] memory trades) external {
 		for (uint i=0; i!=assetsToUnwrap.length; i++) {
 			lendingPool.withdraw(assetsToUnwrap[i], type(uint256).max, address(this));


### PR DESCRIPTION
This PR adds the `WalletZapper` contract

it's supposed to be used only with `Identity` accounts, by transferring funds to it and then calling one of `exchangeV2`, `wrapLending`, `unwrapLending`, `tradeV3`, `tradeV3Single`, `diversifyV3`

the point of this contract is to avoid having to do approvals, although it may be cheaper for single trades to do an approval (has to be measured) 

But when doing multiple trades (`diversifyV3`), it will definitely be cheaper to use the `WalletZapper`