### PR TITLE
EIP 1271: allow smart wallets to verify signed messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 coverage/
 coverage.json
 .vscode
+.deployKey

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -137,8 +137,7 @@ contract Identity {
 
 	// EIP 1271 implementation
 	function isValidSignature(bytes32 hash, bytes calldata signature) external view returns (bytes4) {
-		hash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash));
-		if (privileges[SignatureValidator.recoverAddrBytesNoPrefix(hash, signature)]) {
+		if (privileges[SignatureValidator.recoverAddrBytes(hash, signature)]) {
 			// bytes4(keccak256("isValidSignature(bytes32,bytes)")
 			return 0x1626ba7e;
 		} else {

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -19,6 +19,8 @@ contract Identity {
 	struct Transaction {
 		// replay protection
 		address identityContract;
+		// The nonce is also part of the replay protection, when signing Transaction objects we need to ensure they can be ran only once
+		// this means it doesn't apply to executeBySender
 		uint nonce;
 		// tx fee, in tokens
 		address feeTokenAddr;
@@ -103,10 +105,6 @@ contract Identity {
 		uint len = txns.length;
 		for (uint i=0; i<len; i++) {
 			Transaction memory txn = txns[i];
-			require(txn.nonce == nonce, 'WRONG_NONCE');
-
-			nonce = nonce + 1;
-
 			executeCall(txn.to, txn.value, txn.data);
 		}
 		// The actual anti-bricking mechanism - do not allow the sender to drop his own priviledges

--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -134,4 +134,15 @@ contract Identity {
 			default {}
 		}
 	}
+
+	// EIP 1271 implementation
+	function isValidSignature(bytes32 hash, bytes calldata signature) external view returns (bytes4) {
+		hash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash));
+		if (privileges[SignatureValidator.recoverAddrBytesNoPrefix(hash, signature)]) {
+			// bytes4(keccak256("isValidSignature(bytes32,bytes)")
+			return 0x1626ba7e;
+		} else {
+			return 0xffffffff;
+		}
+	}
 }

--- a/contracts/libs/SignatureValidator.sol
+++ b/contracts/libs/SignatureValidator.sol
@@ -41,10 +41,10 @@ library SignatureValidator {
 
 	/// @notice Recover the signer of hash, assuming it's an EOA account
 	/// @dev Only for EthSign signatures
-	/// @param _hash       Hash of message that was signed
-	/// @param _signature  Signature encoded as (bytes32 r, bytes32 s, uint8 v)
+	/// @param hash       Hash of message that was signed
+	/// @param signature  Signature encoded as (bytes32 r, bytes32 s, uint8 v)
 	/// @return Returns an address of the user who signed
-	function recoverAddrBytesNoPrefix(bytes32 hash, bytes signature) internal pure returns (address) {
+	function recoverAddrBytesNoPrefix(bytes32 hash, bytes memory signature) internal pure returns (address) {
 		// only implements case 65: r,s,v signature (standard)
 		// see https://github.com/OpenZeppelin/openzeppelin-contracts/blob/d3c5bdf4def690228b08e0ac431437288a50e64a/contracts/utils/cryptography/ECDSA.sol#L32
 		require(signature.length == 65, "SignatureValidator: invalid signature length");
@@ -57,7 +57,6 @@ library SignatureValidator {
 			s := mload(add(signature, 0x40))
 			v := byte(0, mload(add(signature, 0x60)))
 		}
-
 
 		// EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature
 		// unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines
@@ -73,9 +72,9 @@ library SignatureValidator {
 		// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/cryptography/ECDSA.sol
 		require(
 			uint256(s) <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0,
-			"ECDSA: invalid signature 's' value"
+			"SignatureValidator: invalid signature 's' value"
 		);
-		require(v == 27 || v == 28, "ECDSA: invalid signature 'v' value");
+		require(v == 27 || v == 28, "SignatureValidator: invalid signature 'v' value");
 		return ecrecover(hash, v, r, s);
 	}
 }

--- a/contracts/libs/SignatureValidator.sol
+++ b/contracts/libs/SignatureValidator.sol
@@ -44,7 +44,7 @@ library SignatureValidator {
 	/// @param _hash       Hash of message that was signed
 	/// @param _signature  Signature encoded as (bytes32 r, bytes32 s, uint8 v)
 	/// @return Returns an address of the user who signed
-	function recoverAddrBytes(bytes32 hash, bytes signature) internal pure returns (address) {
+	function recoverAddrBytesNoPrefix(bytes32 hash, bytes signature) internal pure returns (address) {
 		// only implements case 65: r,s,v signature (standard)
 		// see https://github.com/OpenZeppelin/openzeppelin-contracts/blob/d3c5bdf4def690228b08e0ac431437288a50e64a/contracts/utils/cryptography/ECDSA.sol#L32
 		require(signature.length == 65, "SignatureValidator: invalid signature length");
@@ -76,8 +76,6 @@ library SignatureValidator {
 			"ECDSA: invalid signature 's' value"
 		);
 		require(v == 27 || v == 28, "ECDSA: invalid signature 'v' value");
-
-		hash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash));
 		return ecrecover(hash, v, r, s);
 	}
 }

--- a/contracts/libs/SignatureValidator.sol
+++ b/contracts/libs/SignatureValidator.sol
@@ -44,7 +44,7 @@ library SignatureValidator {
 	/// @param hash       Hash of message that was signed
 	/// @param signature  Signature encoded as (bytes32 r, bytes32 s, uint8 v)
 	/// @return Returns an address of the user who signed
-	function recoverAddrBytesNoPrefix(bytes32 hash, bytes memory signature) internal pure returns (address) {
+	function recoverAddrBytes(bytes32 hash, bytes memory signature) internal pure returns (address) {
 		// only implements case 65: r,s,v signature (standard)
 		// see https://github.com/OpenZeppelin/openzeppelin-contracts/blob/d3c5bdf4def690228b08e0ac431437288a50e64a/contracts/utils/cryptography/ECDSA.sol#L32
 		require(signature.length == 65, "SignatureValidator: invalid signature length");
@@ -75,6 +75,7 @@ library SignatureValidator {
 			"SignatureValidator: invalid signature 's' value"
 		);
 		require(v == 27 || v == 28, "SignatureValidator: invalid signature 'v' value");
+		hash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash));
 		return ecrecover(hash, v, r, s);
 	}
 }

--- a/contracts/libs/SignatureValidator.sol
+++ b/contracts/libs/SignatureValidator.sol
@@ -38,4 +38,46 @@ library SignatureValidator {
 	function isValid(bytes32 hash, address signer, bytes32[3] memory signature) internal pure returns (bool) {
 		return recoverAddr(hash, signature) == signer;
 	}
+
+	/// @notice Recover the signer of hash, assuming it's an EOA account
+	/// @dev Only for EthSign signatures
+	/// @param _hash       Hash of message that was signed
+	/// @param _signature  Signature encoded as (bytes32 r, bytes32 s, uint8 v)
+	/// @return Returns an address of the user who signed
+	function recoverAddrBytes(bytes32 hash, bytes signature) internal pure returns (address) {
+		// only implements case 65: r,s,v signature (standard)
+		// see https://github.com/OpenZeppelin/openzeppelin-contracts/blob/d3c5bdf4def690228b08e0ac431437288a50e64a/contracts/utils/cryptography/ECDSA.sol#L32
+		require(signature.length == 65, "SignatureValidator: invalid signature length");
+
+		bytes32 r;
+		bytes32 s;
+		uint8 v;
+		assembly {
+			r := mload(add(signature, 0x20))
+			s := mload(add(signature, 0x40))
+			v := byte(0, mload(add(signature, 0x60)))
+		}
+
+
+		// EIP-2 still allows signature malleability for ecrecover(). Remove this possibility and make the signature
+		// unique. Appendix F in the Ethereum Yellow paper (https://ethereum.github.io/yellowpaper/paper.pdf), defines
+		// the valid range for s in (281): 0 < s < secp256k1n ÷ 2 + 1, and for v in (282): v ∈ {27, 28}. Most
+		// signatures from current libraries generate a unique signature with an s-value in the lower half order.
+		//
+		// If your library generates malleable signatures, such as s-values in the upper range, calculate a new s-value
+		// with 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141 - s1 and flip v from 27 to 28 or
+		// vice versa. If your library also generates signatures with 0/1 for v instead 27/28, add 27 to v to accept
+		// these malleable signatures as well.
+		//
+		// Source OpenZeppelin
+		// https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/cryptography/ECDSA.sol
+		require(
+			uint256(s) <= 0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF5D576E7357A4501DDFE92F46681B20A0,
+			"ECDSA: invalid signature 's' value"
+		);
+		require(v == 27 || v == 28, "ECDSA: invalid signature 'v' value");
+
+		hash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", hash));
+		return ecrecover(hash, v, r, s);
+	}
 }

--- a/contracts/libs/SignatureValidator.sol
+++ b/contracts/libs/SignatureValidator.sol
@@ -78,34 +78,4 @@ library SignatureValidator {
 		require(v == 27 || v == 28, "ECDSA: invalid signature 'v' value");
 		return ecrecover(hash, v, r, s);
 	}
-
-	/// @notice Recover the signer of hash, assuming it's an EOA account
-	/// @dev adds the "Ethereum signed message" prefix
-	/// @param _hash       Hash of message that was signed
-	/// @param _signature  Signature encoded as (bytes32 r, bytes32 s, uint8 v)
-	/// @return Returns an address of the user who signed
-	function recoverAddrBytesWithPrefix(bytes data, bytes signature) internal pure returns (address) {
-		bytes32 messageHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n", uint2str(data.length), data));
-		return recoverAddrBytesNoPrefix(messageHash, signature);
-	}
-
-	function uint2str(uint num) internal pure returns (string memory uintAsString) {
-		if (_num == 0) {
-			return "0";
-		}
-		uint i = _num;
-		uint j = _num;
-		uint len;
-		while (j != 0) {
-			len++;
-			j /= 10;
-		}
-		bytes memory bstr = new bytes(len);
-		uint k = len - 1;
-		while (i != 0) {
-			bstr[k--] = byte(uint8(48 + i % 10));
-			i /= 10;
-		}
-		return string(bstr);
-	}
 }

--- a/contracts/libs/SignatureValidator.sol
+++ b/contracts/libs/SignatureValidator.sol
@@ -78,4 +78,34 @@ library SignatureValidator {
 		require(v == 27 || v == 28, "ECDSA: invalid signature 'v' value");
 		return ecrecover(hash, v, r, s);
 	}
+
+	/// @notice Recover the signer of hash, assuming it's an EOA account
+	/// @dev adds the "Ethereum signed message" prefix
+	/// @param _hash       Hash of message that was signed
+	/// @param _signature  Signature encoded as (bytes32 r, bytes32 s, uint8 v)
+	/// @return Returns an address of the user who signed
+	function recoverAddrBytesWithPrefix(bytes data, bytes signature) internal pure returns (address) {
+		bytes32 messageHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n", uint2str(data.length), data));
+		return recoverAddrBytesNoPrefix(messageHash, signature);
+	}
+
+	function uint2str(uint num) internal pure returns (string memory uintAsString) {
+		if (_num == 0) {
+			return "0";
+		}
+		uint i = _num;
+		uint j = _num;
+		uint len;
+		while (j != 0) {
+			len++;
+			j /= 10;
+		}
+		bytes memory bstr = new bytes(len);
+		uint k = len - 1;
+		while (i != 0) {
+			bstr[k--] = byte(uint8(48 + i % 10));
+			i /= 10;
+		}
+		return string(bstr);
+	}
 }

--- a/test/TestIdentity.js
+++ b/test/TestIdentity.js
@@ -264,18 +264,6 @@ contract('Identity', function(accounts) {
 			gasLimit
 		})).wait()
 		assert.equal(receipt.events.length, 1, 'right number of events emitted')
-
-		const initialNonce = parseInt(relayerTx.nonce, 10)
-		assert.equal((await id.nonce()).toNumber(), initialNonce + 1, 'nonce has increased with 1')
-
-		const invalidNonceTx = new Transaction({
-			...relayerTx,
-			nonce: initialNonce
-		})
-		await expectEVMError(
-			idWithUser.executeBySender([invalidNonceTx.toSolidityTuple()]),
-			'WRONG_NONCE'
-		)
 	})
 
 	it('actions: channel deposit, withdraw', async function() {


### PR DESCRIPTION
Implements EIP1271: https://eips.ethereum.org/EIPS/eip-1271

Note: that EIP was recently changed to use bytes32 for the hash instead of bytes, which makes the sig verification much simpler. Old implementations still use bytes and as such, they're not compatible
