### PR TITLE
Identity gas optimization

### DIFF
--- a/contracts/Identity.sol
+++ b/contracts/Identity.sol
@@ -19,6 +19,8 @@ contract Identity {
 	struct Transaction {
 		// replay protection
 		address identityContract;
+		// The nonce is also part of the replay protection, when signing Transaction objects we need to ensure they can be ran only once
+		// this means it doesn't apply to executeBySender
 		uint nonce;
 		// tx fee, in tokens
 		address feeTokenAddr;
@@ -103,10 +105,6 @@ contract Identity {
 		uint len = txns.length;
 		for (uint i=0; i<len; i++) {
 			Transaction memory txn = txns[i];
-			require(txn.nonce == nonce, 'WRONG_NONCE');
-
-			nonce = nonce + 1;
-
 			executeCall(txn.to, txn.value, txn.data);
 		}
 		// The actual anti-bricking mechanism - do not allow the sender to drop his own priviledges

--- a/test/TestIdentity.js
+++ b/test/TestIdentity.js
@@ -264,18 +264,6 @@ contract('Identity', function(accounts) {
 			gasLimit
 		})).wait()
 		assert.equal(receipt.events.length, 1, 'right number of events emitted')
-
-		const initialNonce = parseInt(relayerTx.nonce, 10)
-		assert.equal((await id.nonce()).toNumber(), initialNonce + 1, 'nonce has increased with 1')
-
-		const invalidNonceTx = new Transaction({
-			...relayerTx,
-			nonce: initialNonce
-		})
-		await expectEVMError(
-			idWithUser.executeBySender([invalidNonceTx.toSolidityTuple()]),
-			'WRONG_NONCE'
-		)
 	})
 
 	it('actions: channel deposit, withdraw', async function() {


### PR DESCRIPTION
nonce only makes sense when the transactions are being signed: as such, it's not needed in executeBySender